### PR TITLE
Introduce Python import sorting to our sanity test suite (#26768)

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -95,5 +95,7 @@ disable=
 	no-else-return,
 	# NOTE(lidiz): Python 3 make object inheritance default, but not PY2
 	useless-object-inheritance,
+	# NOTE(lidiz): the import order will be enforced by isort instead
+	wrong-import-order,
   # NOTE(sergiitk): yapf compatibility, ref #25071
   bad-continuation,

--- a/.pylintrc-examples
+++ b/.pylintrc-examples
@@ -98,5 +98,7 @@ disable=
 	no-else-return,
 	# NOTE(lidiz): Python 3 make object inheritance default, but not PY2
 	useless-object-inheritance,
+	# NOTE(lidiz): the import order will be enforced by isort instead
+	wrong-import-order,
   # NOTE(sergiitk): yapf compatibility, ref #25071
   bad-continuation,

--- a/.pylintrc-tests
+++ b/.pylintrc-tests
@@ -124,5 +124,7 @@ disable=
 	no-else-return,
 	# NOTE(lidiz): Python 3 make object inheritance default, but not PY2
 	useless-object-inheritance,
+	# NOTE(lidiz): the import order will be enforced by isort instead
+	wrong-import-order,
   # NOTE(sergiitk): yapf compatibility, ref #25071
   bad-continuation,

--- a/examples/python/async_streaming/client.py
+++ b/examples/python/async_streaming/client.py
@@ -12,10 +12,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from concurrent.futures import ThreadPoolExecutor
 import logging
 import threading
 from typing import Iterator
-from concurrent.futures import ThreadPoolExecutor
 
 import grpc
 

--- a/examples/python/async_streaming/server.py
+++ b/examples/python/async_streaming/server.py
@@ -12,14 +12,14 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import logging
-import time
 from concurrent.futures import ThreadPoolExecutor
-from typing import Iterable
+import logging
 import threading
+import time
+from typing import Iterable
 
-import grpc
 from google.protobuf.json_format import MessageToJson
+import grpc
 
 import phone_pb2
 import phone_pb2_grpc

--- a/examples/python/auth/async_customized_auth_client.py
+++ b/examples/python/auth/async_customized_auth_client.py
@@ -17,9 +17,8 @@ import argparse
 import asyncio
 import logging
 
-import grpc
-
 import _credentials
+import grpc
 
 helloworld_pb2, helloworld_pb2_grpc = grpc.protos_and_services(
     "helloworld.proto")

--- a/examples/python/auth/async_customized_auth_server.py
+++ b/examples/python/auth/async_customized_auth_server.py
@@ -18,9 +18,8 @@ import asyncio
 import logging
 from typing import Awaitable, Callable, Tuple
 
-import grpc
-
 import _credentials
+import grpc
 
 helloworld_pb2, helloworld_pb2_grpc = grpc.protos_and_services(
     "helloworld.proto")

--- a/examples/python/auth/customized_auth_client.py
+++ b/examples/python/auth/customized_auth_client.py
@@ -17,8 +17,8 @@ import argparse
 import contextlib
 import logging
 
-import grpc
 import _credentials
+import grpc
 
 helloworld_pb2, helloworld_pb2_grpc = grpc.protos_and_services(
     "helloworld.proto")

--- a/examples/python/auth/customized_auth_server.py
+++ b/examples/python/auth/customized_auth_server.py
@@ -14,12 +14,12 @@
 """Server of the Python example of customizing authentication mechanism."""
 
 import argparse
+from concurrent import futures
 import contextlib
 import logging
-from concurrent import futures
 
-import grpc
 import _credentials
+import grpc
 
 helloworld_pb2, helloworld_pb2_grpc = grpc.protos_and_services(
     "helloworld.proto")

--- a/examples/python/auth/test/_auth_example_test.py
+++ b/examples/python/auth/test/_auth_example_test.py
@@ -17,11 +17,12 @@ import asyncio
 import unittest
 
 import grpc
+
 from examples.python.auth import _credentials
-from examples.python.auth import customized_auth_client
-from examples.python.auth import customized_auth_server
 from examples.python.auth import async_customized_auth_client
 from examples.python.auth import async_customized_auth_server
+from examples.python.auth import customized_auth_client
+from examples.python.auth import customized_auth_server
 
 _SERVER_ADDR_TEMPLATE = 'localhost:%d'
 

--- a/examples/python/cancellation/server.py
+++ b/examples/python/cancellation/server.py
@@ -17,8 +17,8 @@ from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
 
-from concurrent import futures
 import argparse
+from concurrent import futures
 import logging
 import threading
 

--- a/examples/python/compression/client.py
+++ b/examples/python/compression/client.py
@@ -19,6 +19,7 @@ from __future__ import print_function
 
 import argparse
 import logging
+
 import grpc
 
 from examples.protos import helloworld_pb2

--- a/examples/python/compression/server.py
+++ b/examples/python/compression/server.py
@@ -17,10 +17,11 @@ from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
 
-from concurrent import futures
 import argparse
+from concurrent import futures
 import logging
 import threading
+
 import grpc
 
 from examples.protos import helloworld_pb2

--- a/examples/python/data_transmission/alts_client.py
+++ b/examples/python/data_transmission/alts_client.py
@@ -17,9 +17,11 @@ The example would only successfully run in GCP environment."""
 
 import grpc
 
+from client import bidirectional_streaming_method
+from client import client_streaming_method
+from client import server_streaming_method
+from client import simple_method
 import demo_pb2_grpc
-from client import (bidirectional_streaming_method, client_streaming_method,
-                    server_streaming_method, simple_method)
 
 SERVER_ADDRESS = "localhost:23333"
 

--- a/examples/python/data_transmission/client.py
+++ b/examples/python/data_transmission/client.py
@@ -14,10 +14,11 @@
 """The example of four ways of data transmission using gRPC in Python."""
 
 import time
+
 import grpc
 
-import demo_pb2_grpc
 import demo_pb2
+import demo_pb2_grpc
 
 __all__ = [
     'simple_method', 'client_streaming_method', 'server_streaming_method',

--- a/examples/python/data_transmission/server.py
+++ b/examples/python/data_transmission/server.py
@@ -13,12 +13,13 @@
 # limitations under the License.
 """The example of four ways of data transmission using gRPC in Python."""
 
-from threading import Thread
 from concurrent import futures
+from threading import Thread
 
 import grpc
-import demo_pb2_grpc
+
 import demo_pb2
+import demo_pb2_grpc
 
 __all__ = 'DemoServer'
 SERVER_ADDRESS = 'localhost:23333'

--- a/examples/python/debug/asyncio_debug_server.py
+++ b/examples/python/debug/asyncio_debug_server.py
@@ -13,8 +13,8 @@
 # limitations under the License.
 """The Python AsyncIO example of utilizing Channelz feature."""
 
-import asyncio
 import argparse
+import asyncio
 import logging
 import random
 

--- a/examples/python/debug/asyncio_get_stats.py
+++ b/examples/python/debug/asyncio_get_stats.py
@@ -13,11 +13,11 @@
 # limitations under the License.
 """Poll statistics from the server."""
 
+import argparse
 import asyncio
 import logging
-import argparse
-import grpc
 
+import grpc
 from grpc_channelz.v1 import channelz_pb2
 from grpc_channelz.v1 import channelz_pb2_grpc
 

--- a/examples/python/debug/asyncio_send_message.py
+++ b/examples/python/debug/asyncio_send_message.py
@@ -13,9 +13,10 @@
 # limitations under the License.
 """Send multiple greeting messages to the backend."""
 
+import argparse
 import asyncio
 import logging
-import argparse
+
 import grpc
 
 helloworld_pb2, helloworld_pb2_grpc = grpc.protos_and_services(

--- a/examples/python/debug/debug_server.py
+++ b/examples/python/debug/debug_server.py
@@ -18,8 +18,8 @@ from __future__ import division
 from __future__ import print_function
 
 import argparse
-import logging
 from concurrent import futures
+import logging
 import random
 
 import grpc

--- a/examples/python/debug/get_stats.py
+++ b/examples/python/debug/get_stats.py
@@ -17,10 +17,10 @@ from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
 
-import logging
 import argparse
-import grpc
+import logging
 
+import grpc
 from grpc_channelz.v1 import channelz_pb2
 from grpc_channelz.v1 import channelz_pb2_grpc
 

--- a/examples/python/debug/send_message.py
+++ b/examples/python/debug/send_message.py
@@ -17,8 +17,9 @@ from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
 
-import logging
 import argparse
+import logging
+
 import grpc
 
 helloworld_pb2, helloworld_pb2_grpc = grpc.protos_and_services(

--- a/examples/python/debug/test/_debug_example_test.py
+++ b/examples/python/debug/test/_debug_example_test.py
@@ -17,12 +17,12 @@ import asyncio
 import logging
 import unittest
 
-from examples.python.debug import debug_server
 from examples.python.debug import asyncio_debug_server
-from examples.python.debug import send_message
-from examples.python.debug import asyncio_send_message
-from examples.python.debug import get_stats
 from examples.python.debug import asyncio_get_stats
+from examples.python.debug import asyncio_send_message
+from examples.python.debug import debug_server
+from examples.python.debug import get_stats
+from examples.python.debug import send_message
 
 _LOGGER = logging.getLogger(__name__)
 _LOGGER.setLevel(logging.INFO)

--- a/examples/python/errors/client.py
+++ b/examples/python/errors/client.py
@@ -14,11 +14,12 @@
 """This example handles rich error status in client-side."""
 
 from __future__ import print_function
+
 import logging
 
+from google.rpc import error_details_pb2
 import grpc
 from grpc_status import rpc_status
-from google.rpc import error_details_pb2
 
 from examples.protos import helloworld_pb2
 from examples.protos import helloworld_pb2_grpc

--- a/examples/python/errors/server.py
+++ b/examples/python/errors/server.py
@@ -17,11 +17,12 @@ from concurrent import futures
 import logging
 import threading
 
+from google.protobuf import any_pb2
+from google.rpc import code_pb2
+from google.rpc import error_details_pb2
+from google.rpc import status_pb2
 import grpc
 from grpc_status import rpc_status
-
-from google.protobuf import any_pb2
-from google.rpc import code_pb2, status_pb2, error_details_pb2
 
 from examples.protos import helloworld_pb2
 from examples.protos import helloworld_pb2_grpc

--- a/examples/python/errors/test/_error_handling_example_test.py
+++ b/examples/python/errors/test/_error_handling_example_test.py
@@ -21,8 +21,8 @@ try:
 except ImportError:
     pass
 
-import unittest
 import logging
+import unittest
 
 import grpc
 

--- a/examples/python/helloworld/async_greeter_client.py
+++ b/examples/python/helloworld/async_greeter_client.py
@@ -13,10 +13,10 @@
 # limitations under the License.
 """The Python AsyncIO implementation of the GRPC helloworld.Greeter client."""
 
-import logging
 import asyncio
-import grpc
+import logging
 
+import grpc
 import helloworld_pb2
 import helloworld_pb2_grpc
 

--- a/examples/python/helloworld/async_greeter_client_with_options.py
+++ b/examples/python/helloworld/async_greeter_client_with_options.py
@@ -17,7 +17,6 @@ import asyncio
 import logging
 
 import grpc
-
 import helloworld_pb2
 import helloworld_pb2_grpc
 

--- a/examples/python/helloworld/async_greeter_server.py
+++ b/examples/python/helloworld/async_greeter_server.py
@@ -13,10 +13,10 @@
 # limitations under the License.
 """The Python AsyncIO implementation of the GRPC helloworld.Greeter server."""
 
-import logging
 import asyncio
-import grpc
+import logging
 
+import grpc
 import helloworld_pb2
 import helloworld_pb2_grpc
 

--- a/examples/python/helloworld/async_greeter_server_with_graceful_shutdown.py
+++ b/examples/python/helloworld/async_greeter_server_with_graceful_shutdown.py
@@ -13,10 +13,10 @@
 # limitations under the License.
 """The graceful shutdown example for the asyncio Greeter server."""
 
-import logging
 import asyncio
-import grpc
+import logging
 
+import grpc
 import helloworld_pb2
 import helloworld_pb2_grpc
 

--- a/examples/python/helloworld/async_greeter_server_with_reflection.py
+++ b/examples/python/helloworld/async_greeter_server_with_reflection.py
@@ -18,7 +18,6 @@ import logging
 
 import grpc
 from grpc_reflection.v1alpha import reflection
-
 import helloworld_pb2
 import helloworld_pb2_grpc
 

--- a/examples/python/helloworld/greeter_client.py
+++ b/examples/python/helloworld/greeter_client.py
@@ -14,10 +14,10 @@
 """The Python implementation of the GRPC helloworld.Greeter client."""
 
 from __future__ import print_function
+
 import logging
 
 import grpc
-
 import helloworld_pb2
 import helloworld_pb2_grpc
 

--- a/examples/python/helloworld/greeter_client_with_options.py
+++ b/examples/python/helloworld/greeter_client_with_options.py
@@ -14,10 +14,10 @@
 """gRPC Python helloworld.Greeter client with channel options and call timeout parameters."""
 
 from __future__ import print_function
+
 import logging
 
 import grpc
-
 import helloworld_pb2
 import helloworld_pb2_grpc
 

--- a/examples/python/helloworld/greeter_server.py
+++ b/examples/python/helloworld/greeter_server.py
@@ -17,7 +17,6 @@ from concurrent import futures
 import logging
 
 import grpc
-
 import helloworld_pb2
 import helloworld_pb2_grpc
 

--- a/examples/python/helloworld/greeter_server_with_reflection.py
+++ b/examples/python/helloworld/greeter_server_with_reflection.py
@@ -18,7 +18,6 @@ import logging
 
 import grpc
 from grpc_reflection.v1alpha import reflection
-
 import helloworld_pb2
 import helloworld_pb2_grpc
 

--- a/examples/python/interceptors/default_value/greeter_client.py
+++ b/examples/python/interceptors/default_value/greeter_client.py
@@ -14,13 +14,13 @@
 """The Python implementation of the gRPC helloworld.Greeter client."""
 
 from __future__ import print_function
+
 import logging
 
+import default_value_client_interceptor
 import grpc
-
 import helloworld_pb2
 import helloworld_pb2_grpc
-import default_value_client_interceptor
 
 
 def run():

--- a/examples/python/interceptors/headers/greeter_client.py
+++ b/examples/python/interceptors/headers/greeter_client.py
@@ -14,13 +14,13 @@
 """The Python implementation of the GRPC helloworld.Greeter client."""
 
 from __future__ import print_function
+
 import logging
 
 import grpc
-
+import header_manipulator_client_interceptor
 import helloworld_pb2
 import helloworld_pb2_grpc
-import header_manipulator_client_interceptor
 
 
 def run():

--- a/examples/python/interceptors/headers/greeter_server.py
+++ b/examples/python/interceptors/headers/greeter_server.py
@@ -17,10 +17,10 @@ from concurrent import futures
 import logging
 
 import grpc
-
 import helloworld_pb2
 import helloworld_pb2_grpc
-from request_header_validator_interceptor import RequestHeaderValidatorInterceptor
+from request_header_validator_interceptor import \
+    RequestHeaderValidatorInterceptor
 
 
 class Greeter(helloworld_pb2_grpc.GreeterServicer):

--- a/examples/python/interceptors/headers/header_manipulator_client_interceptor.py
+++ b/examples/python/interceptors/headers/header_manipulator_client_interceptor.py
@@ -15,8 +15,8 @@
 
 import collections
 
-import grpc
 import generic_client_interceptor
+import grpc
 
 
 class _ClientCallDetails(

--- a/examples/python/metadata/metadata_client.py
+++ b/examples/python/metadata/metadata_client.py
@@ -14,10 +14,10 @@
 """Example gRPC client that gets/sets metadata (HTTP2 headers)"""
 
 from __future__ import print_function
+
 import logging
 
 import grpc
-
 import helloworld_pb2
 import helloworld_pb2_grpc
 

--- a/examples/python/metadata/metadata_server.py
+++ b/examples/python/metadata/metadata_server.py
@@ -14,11 +14,11 @@
 """Example gRPC server that gets/sets metadata (HTTP2 headers)"""
 
 from __future__ import print_function
+
 from concurrent import futures
 import logging
 
 import grpc
-
 import helloworld_pb2
 import helloworld_pb2_grpc
 

--- a/examples/python/multiplex/multiplex_client.py
+++ b/examples/python/multiplex/multiplex_client.py
@@ -15,12 +15,11 @@
 
 from __future__ import print_function
 
+import logging
 import random
 import time
-import logging
 
 import grpc
-
 import helloworld_pb2
 import helloworld_pb2_grpc
 import route_guide_pb2

--- a/examples/python/multiplex/multiplex_server.py
+++ b/examples/python/multiplex/multiplex_server.py
@@ -14,12 +14,11 @@
 """A gRPC server servicing both Greeter and RouteGuide RPCs."""
 
 from concurrent import futures
-import time
-import math
 import logging
+import math
+import time
 
 import grpc
-
 import helloworld_pb2
 import helloworld_pb2_grpc
 import route_guide_pb2

--- a/examples/python/multiprocessing/client.py
+++ b/examples/python/multiprocessing/client.py
@@ -25,7 +25,6 @@ import operator
 import sys
 
 import grpc
-
 import prime_pb2
 import prime_pb2_grpc
 

--- a/examples/python/multiprocessing/server.py
+++ b/examples/python/multiprocessing/server.py
@@ -23,12 +23,11 @@ import datetime
 import logging
 import math
 import multiprocessing
-import time
 import socket
 import sys
+import time
 
 import grpc
-
 import prime_pb2
 import prime_pb2_grpc
 

--- a/examples/python/no_codegen/greeter_client.py
+++ b/examples/python/no_codegen/greeter_client.py
@@ -20,6 +20,7 @@ Several APIs used in this example are in an experimental state.
 """
 
 from __future__ import print_function
+
 import logging
 
 import grpc

--- a/examples/python/route_guide/asyncio_route_guide_client.py
+++ b/examples/python/route_guide/asyncio_route_guide_client.py
@@ -14,12 +14,11 @@
 """The Python AsyncIO implementation of the gRPC route guide client."""
 
 import asyncio
-import random
 import logging
-from typing import List, Iterable
+import random
+from typing import Iterable, List
 
 import grpc
-
 import route_guide_pb2
 import route_guide_pb2_grpc
 import route_guide_resources

--- a/examples/python/route_guide/asyncio_route_guide_server.py
+++ b/examples/python/route_guide/asyncio_route_guide_server.py
@@ -14,13 +14,12 @@
 """The Python AsyncIO implementation of the gRPC route guide server."""
 
 import asyncio
-import time
-import math
 import logging
+import math
+import time
 from typing import AsyncIterable, Iterable
 
 import grpc
-
 import route_guide_pb2
 import route_guide_pb2_grpc
 import route_guide_resources

--- a/examples/python/route_guide/route_guide_client.py
+++ b/examples/python/route_guide/route_guide_client.py
@@ -15,11 +15,10 @@
 
 from __future__ import print_function
 
-import random
 import logging
+import random
 
 import grpc
-
 import route_guide_pb2
 import route_guide_pb2_grpc
 import route_guide_resources

--- a/examples/python/route_guide/route_guide_server.py
+++ b/examples/python/route_guide/route_guide_server.py
@@ -14,12 +14,11 @@
 """The Python implementation of the gRPC route guide server."""
 
 from concurrent import futures
-import time
-import math
 import logging
+import math
+import time
 
 import grpc
-
 import route_guide_pb2
 import route_guide_pb2_grpc
 import route_guide_resources

--- a/examples/python/wait_for_ready/asyncio_wait_for_ready_example.py
+++ b/examples/python/wait_for_ready/asyncio_wait_for_ready_example.py
@@ -14,8 +14,8 @@
 """The Python example of utilizing wait-for-ready flag."""
 
 import asyncio
-import logging
 from contextlib import contextmanager
+import logging
 import socket
 from typing import Iterable
 

--- a/examples/python/wait_for_ready/test/_wait_for_ready_example_test.py
+++ b/examples/python/wait_for_ready/test/_wait_for_ready_example_test.py
@@ -14,11 +14,11 @@
 """Tests of the wait-for-ready example."""
 
 import asyncio
-import unittest
 import logging
+import unittest
 
-from examples.python.wait_for_ready import wait_for_ready_example
 from examples.python.wait_for_ready import asyncio_wait_for_ready_example
+from examples.python.wait_for_ready import wait_for_ready_example
 
 
 class WaitForReadyExampleTest(unittest.TestCase):

--- a/examples/python/wait_for_ready/wait_for_ready_example.py
+++ b/examples/python/wait_for_ready/wait_for_ready_example.py
@@ -13,9 +13,9 @@
 # limitations under the License.
 """The Python example of utilizing wait-for-ready flag."""
 
-import logging
 from concurrent import futures
 from contextlib import contextmanager
+import logging
 import socket
 import threading
 

--- a/examples/python/xds/client.py
+++ b/examples/python/xds/client.py
@@ -14,12 +14,12 @@
 """The Python implementation of the GRPC helloworld.Greeter client."""
 
 from __future__ import print_function
-import logging
+
 import argparse
+import logging
 
 import grpc
 import grpc.experimental
-
 import helloworld_pb2
 import helloworld_pb2_grpc
 

--- a/examples/python/xds/server.py
+++ b/examples/python/xds/server.py
@@ -13,20 +13,18 @@
 # limitations under the License.
 """The Python implementation of the GRPC helloworld.Greeter server."""
 
-from concurrent import futures
 import argparse
+from concurrent import futures
 import logging
 import socket
 
 import grpc
-
-import helloworld_pb2
-import helloworld_pb2_grpc
-
-from grpc_reflection.v1alpha import reflection
 from grpc_health.v1 import health
 from grpc_health.v1 import health_pb2
 from grpc_health.v1 import health_pb2_grpc
+from grpc_reflection.v1alpha import reflection
+import helloworld_pb2
+import helloworld_pb2_grpc
 
 _DESCRIPTION = "A general purpose phony server."
 

--- a/setup.py
+++ b/setup.py
@@ -15,11 +15,12 @@
 
 # setuptools need to be imported before distutils. Otherwise it might lead to
 # undesirable behaviors or errors.
-import setuptools
+import setuptools  # isort:skip
 
 # Monkey Patch the unix compiler to accept ASM
 # files used by boring SSL.
 from distutils.unixccompiler import UnixCCompiler
+
 UnixCCompiler.src_extensions.append('.S')
 del UnixCCompiler
 
@@ -28,20 +29,18 @@ from distutils import extension as _extension
 from distutils import util
 import os
 import os.path
-import pkg_resources
 import platform
 import re
 import shlex
 import shutil
+import subprocess
+from subprocess import PIPE
 import sys
 import sysconfig
 
-from setuptools.command import egg_info
-
-import subprocess
-from subprocess import PIPE
-
 import _metadata
+import pkg_resources
+from setuptools.command import egg_info
 
 # Redirect the manifest template from MANIFEST.in to PYTHON-MANIFEST.in.
 egg_info.manifest_maker.template = 'PYTHON-MANIFEST.in'
@@ -86,8 +85,9 @@ sys.path.insert(0, os.path.abspath(PYTHON_STEM))
 # Break import-style to ensure we can actually find our in-repo dependencies.
 import _parallel_compile_patch
 import _spawn_patch
-import commands
 import grpc_core_dependencies
+
+import commands
 import grpc_version
 
 _parallel_compile_patch.monkeypatch_compile_maybe()

--- a/src/python/grpcio/commands.py
+++ b/src/python/grpcio/commands.py
@@ -33,7 +33,6 @@ from setuptools.command import build_py
 from setuptools.command import easy_install
 from setuptools.command import install
 from setuptools.command import test
-
 import support
 
 PYTHON_STEM = os.path.dirname(os.path.abspath(__file__))

--- a/src/python/grpcio/grpc/__init__.py
+++ b/src/python/grpcio/grpc/__init__.py
@@ -18,14 +18,18 @@ import contextlib
 import enum
 import logging
 import sys
-import six
 
-from grpc._cython import cygrpc as _cygrpc
 from grpc import _compression
+from grpc._cython import cygrpc as _cygrpc
+from grpc._runtime_protos import protos
+from grpc._runtime_protos import protos_and_services
+from grpc._runtime_protos import services
+import six
 
 logging.getLogger(__name__).addHandler(logging.NullHandler())
 
 try:
+    # pylint: disable=ungrouped-imports
     from grpc._grpcio_metadata import __version__
 except ImportError:
     __version__ = "dev0"
@@ -2091,8 +2095,6 @@ class Compression(enum.IntEnum):
     Deflate = _compression.Deflate
     Gzip = _compression.Gzip
 
-
-from grpc._runtime_protos import protos, services, protos_and_services  # pylint: disable=wrong-import-position
 
 ###################################  __all__  #################################
 

--- a/src/python/grpcio/grpc/_channel.py
+++ b/src/python/grpcio/grpc/_channel.py
@@ -22,11 +22,11 @@ import threading
 import time
 
 import grpc
-import grpc.experimental
-from grpc import _compression
 from grpc import _common
+from grpc import _compression
 from grpc import _grpcio_metadata
 from grpc._cython import cygrpc
+import grpc.experimental
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/src/python/grpcio/grpc/_common.py
+++ b/src/python/grpcio/grpc/_common.py
@@ -15,10 +15,10 @@
 
 import logging
 import time
-import six
 
 import grpc
 from grpc._cython import cygrpc
+import six
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/src/python/grpcio/grpc/_plugin_wrapping.py
+++ b/src/python/grpcio/grpc/_plugin_wrapping.py
@@ -72,6 +72,7 @@ class _Plugin(object):
 
         try:
             import contextvars  # pylint: disable=wrong-import-position
+
             # The plugin may be invoked on a thread created by Core, which will not
             # have the context propagated. This context is stored and installed in
             # the thread invoking the plugin.

--- a/src/python/grpcio/grpc/_server.py
+++ b/src/python/grpcio/grpc/_server.py
@@ -14,19 +14,18 @@
 """Service-side implementation of gRPC Python."""
 
 import collections
+from concurrent import futures
 import enum
 import logging
 import threading
 import time
-
-from concurrent import futures
-import six
 
 import grpc
 from grpc import _common
 from grpc import _compression
 from grpc import _interceptor
 from grpc._cython import cygrpc
+import six
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/src/python/grpcio/grpc/_simple_stubs.py
+++ b/src/python/grpcio/grpc/_simple_stubs.py
@@ -15,8 +15,8 @@
 
 import collections
 import datetime
-import os
 import logging
+import os
 import threading
 from typing import (Any, AnyStr, Callable, Dict, Iterator, Optional, Sequence,
                     Tuple, TypeVar, Union)

--- a/src/python/grpcio/grpc/_utilities.py
+++ b/src/python/grpcio/grpc/_utilities.py
@@ -14,14 +14,13 @@
 """Internal utilities for gRPC Python."""
 
 import collections
+import logging
 import threading
 import time
-import logging
-
-import six
 
 import grpc
 from grpc import _common
+import six
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/src/python/grpcio/grpc/aio/__init__.py
+++ b/src/python/grpcio/grpc/aio/__init__.py
@@ -20,27 +20,41 @@ created. AsyncIO doesn't provide thread safety for most of its APIs.
 from typing import Any, Optional, Sequence, Tuple
 
 import grpc
-from grpc._cython.cygrpc import (init_grpc_aio, shutdown_grpc_aio, EOF,
-                                 AbortError, BaseError, InternalError,
-                                 UsageError)
+from grpc._cython.cygrpc import AbortError
+from grpc._cython.cygrpc import BaseError
+from grpc._cython.cygrpc import EOF
+from grpc._cython.cygrpc import InternalError
+from grpc._cython.cygrpc import UsageError
+from grpc._cython.cygrpc import init_grpc_aio
+from grpc._cython.cygrpc import shutdown_grpc_aio
 
-from ._base_call import (Call, RpcContext, StreamStreamCall, StreamUnaryCall,
-                         UnaryStreamCall, UnaryUnaryCall)
-from ._base_channel import (Channel, StreamStreamMultiCallable,
-                            StreamUnaryMultiCallable, UnaryStreamMultiCallable,
-                            UnaryUnaryMultiCallable)
+from ._base_call import Call
+from ._base_call import RpcContext
+from ._base_call import StreamStreamCall
+from ._base_call import StreamUnaryCall
+from ._base_call import UnaryStreamCall
+from ._base_call import UnaryUnaryCall
+from ._base_channel import Channel
+from ._base_channel import StreamStreamMultiCallable
+from ._base_channel import StreamUnaryMultiCallable
+from ._base_channel import UnaryStreamMultiCallable
+from ._base_channel import UnaryUnaryMultiCallable
+from ._base_server import Server
+from ._base_server import ServicerContext
 from ._call import AioRpcError
-from ._interceptor import (ClientCallDetails, ClientInterceptor,
-                           InterceptedUnaryUnaryCall,
-                           UnaryUnaryClientInterceptor,
-                           UnaryStreamClientInterceptor,
-                           StreamUnaryClientInterceptor,
-                           StreamStreamClientInterceptor, ServerInterceptor)
-from ._server import server
-from ._base_server import Server, ServicerContext
-from ._typing import ChannelArgumentType
-from ._channel import insecure_channel, secure_channel
+from ._channel import insecure_channel
+from ._channel import secure_channel
+from ._interceptor import ClientCallDetails
+from ._interceptor import ClientInterceptor
+from ._interceptor import InterceptedUnaryUnaryCall
+from ._interceptor import ServerInterceptor
+from ._interceptor import StreamStreamClientInterceptor
+from ._interceptor import StreamUnaryClientInterceptor
+from ._interceptor import UnaryStreamClientInterceptor
+from ._interceptor import UnaryUnaryClientInterceptor
 from ._metadata import Metadata
+from ._server import server
+from ._typing import ChannelArgumentType
 
 ###################################  __all__  #################################
 

--- a/src/python/grpcio/grpc/aio/_base_call.py
+++ b/src/python/grpcio/grpc/aio/_base_call.py
@@ -18,13 +18,17 @@ its information. They also offer methods to manipulate the life-cycle of the
 RPC, e.g. cancellation.
 """
 
-from abc import ABCMeta, abstractmethod
+from abc import ABCMeta
+from abc import abstractmethod
 from typing import AsyncIterable, Awaitable, Generic, Optional, Union
 
 import grpc
 
-from ._typing import (DoneCallbackType, EOFType, RequestType, ResponseType)
 from ._metadata import Metadata
+from ._typing import DoneCallbackType
+from ._typing import EOFType
+from ._typing import RequestType
+from ._typing import ResponseType
 
 __all__ = 'RpcContext', 'Call', 'UnaryUnaryCall', 'UnaryStreamCall'
 

--- a/src/python/grpcio/grpc/aio/_base_channel.py
+++ b/src/python/grpcio/grpc/aio/_base_channel.py
@@ -19,9 +19,10 @@ from typing import Any, Optional
 import grpc
 
 from . import _base_call
-from ._typing import (DeserializingFunction, RequestIterableType,
-                      SerializingFunction)
 from ._metadata import Metadata
+from ._typing import DeserializingFunction
+from ._typing import RequestIterableType
+from ._typing import SerializingFunction
 
 
 class UnaryUnaryMultiCallable(abc.ABC):

--- a/src/python/grpcio/grpc/aio/_base_server.py
+++ b/src/python/grpcio/grpc/aio/_base_server.py
@@ -14,12 +14,13 @@
 """Abstract base classes for server-side classes."""
 
 import abc
-from typing import Generic, Mapping, Optional, Iterable, Sequence
+from typing import Generic, Iterable, Mapping, Optional, Sequence
 
 import grpc
 
-from ._typing import RequestType, ResponseType
 from ._metadata import Metadata
+from ._typing import RequestType
+from ._typing import ResponseType
 
 
 class Server(abc.ABC):

--- a/src/python/grpcio/grpc/aio/_call.py
+++ b/src/python/grpcio/grpc/aio/_call.py
@@ -15,9 +15,9 @@
 
 import asyncio
 import enum
+from functools import partial
 import inspect
 import logging
-from functools import partial
 import traceback
 from typing import AsyncIterable, Optional, Tuple
 
@@ -27,9 +27,13 @@ from grpc._cython import cygrpc
 
 from . import _base_call
 from ._metadata import Metadata
-from ._typing import (DeserializingFunction, DoneCallbackType, MetadatumType,
-                      RequestIterableType, RequestType, ResponseType,
-                      SerializingFunction)
+from ._typing import DeserializingFunction
+from ._typing import DoneCallbackType
+from ._typing import MetadatumType
+from ._typing import RequestIterableType
+from ._typing import RequestType
+from ._typing import ResponseType
+from ._typing import SerializingFunction
 
 __all__ = 'AioRpcError', 'Call', 'UnaryUnaryCall', 'UnaryStreamCall'
 

--- a/src/python/grpcio/grpc/aio/_channel.py
+++ b/src/python/grpcio/grpc/aio/_channel.py
@@ -15,23 +15,34 @@
 
 import asyncio
 import sys
-from typing import Any, Iterable, Optional, Sequence, List
+from typing import Any, Iterable, List, Optional, Sequence
 
 import grpc
-from grpc import _common, _compression, _grpcio_metadata
+from grpc import _common
+from grpc import _compression
+from grpc import _grpcio_metadata
 from grpc._cython import cygrpc
 
-from . import _base_call, _base_channel
-from ._call import (StreamStreamCall, StreamUnaryCall, UnaryStreamCall,
-                    UnaryUnaryCall)
-from ._interceptor import (
-    InterceptedUnaryUnaryCall, InterceptedUnaryStreamCall,
-    InterceptedStreamUnaryCall, InterceptedStreamStreamCall, ClientInterceptor,
-    UnaryUnaryClientInterceptor, UnaryStreamClientInterceptor,
-    StreamUnaryClientInterceptor, StreamStreamClientInterceptor)
+from . import _base_call
+from . import _base_channel
+from ._call import StreamStreamCall
+from ._call import StreamUnaryCall
+from ._call import UnaryStreamCall
+from ._call import UnaryUnaryCall
+from ._interceptor import ClientInterceptor
+from ._interceptor import InterceptedStreamStreamCall
+from ._interceptor import InterceptedStreamUnaryCall
+from ._interceptor import InterceptedUnaryStreamCall
+from ._interceptor import InterceptedUnaryUnaryCall
+from ._interceptor import StreamStreamClientInterceptor
+from ._interceptor import StreamUnaryClientInterceptor
+from ._interceptor import UnaryStreamClientInterceptor
+from ._interceptor import UnaryUnaryClientInterceptor
 from ._metadata import Metadata
-from ._typing import (ChannelArgumentType, DeserializingFunction,
-                      SerializingFunction, RequestIterableType)
+from ._typing import ChannelArgumentType
+from ._typing import DeserializingFunction
+from ._typing import RequestIterableType
+from ._typing import SerializingFunction
 from ._utils import _timeout_to_deadline
 
 _USER_AGENT = 'grpc-python-asyncio/{}'.format(_grpcio_metadata.__version__)

--- a/src/python/grpcio/grpc/aio/_interceptor.py
+++ b/src/python/grpcio/grpc/aio/_interceptor.py
@@ -12,24 +12,35 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 """Interceptors implementation of gRPC Asyncio Python."""
+from abc import ABCMeta
+from abc import abstractmethod
 import asyncio
 import collections
 import functools
-from abc import ABCMeta, abstractmethod
-from typing import Callable, Optional, Iterator, Sequence, Union, Awaitable, AsyncIterable
+from typing import (AsyncIterable, Awaitable, Callable, Iterator, Optional,
+                    Sequence, Union)
 
 import grpc
 from grpc._cython import cygrpc
 
 from . import _base_call
-from ._call import UnaryUnaryCall, UnaryStreamCall, StreamUnaryCall, StreamStreamCall, AioRpcError
-from ._call import _RPC_ALREADY_FINISHED_DETAILS, _RPC_HALF_CLOSED_DETAILS
+from ._call import AioRpcError
+from ._call import StreamStreamCall
+from ._call import StreamUnaryCall
+from ._call import UnaryStreamCall
+from ._call import UnaryUnaryCall
 from ._call import _API_STYLE_ERROR
-from ._utils import _timeout_to_deadline
-from ._typing import (RequestType, SerializingFunction, DeserializingFunction,
-                      ResponseType, DoneCallbackType, RequestIterableType,
-                      ResponseIterableType)
+from ._call import _RPC_ALREADY_FINISHED_DETAILS
+from ._call import _RPC_HALF_CLOSED_DETAILS
 from ._metadata import Metadata
+from ._typing import DeserializingFunction
+from ._typing import DoneCallbackType
+from ._typing import RequestIterableType
+from ._typing import RequestType
+from ._typing import ResponseIterableType
+from ._typing import ResponseType
+from ._typing import SerializingFunction
+from ._utils import _timeout_to_deadline
 
 _LOCAL_CANCELLATION_DETAILS = 'Locally cancelled by application!'
 

--- a/src/python/grpcio/grpc/aio/_metadata.py
+++ b/src/python/grpcio/grpc/aio/_metadata.py
@@ -12,8 +12,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 """Implementation of the metadata abstraction for gRPC Asyncio Python."""
-from typing import List, Tuple, Iterator, Any, Union
-from collections import abc, OrderedDict
+from collections import OrderedDict
+from collections import abc
+from typing import Any, Iterator, List, Tuple, Union
 
 MetadataKey = str
 MetadataValue = Union[str, bytes]

--- a/src/python/grpcio/grpc/aio/_server.py
+++ b/src/python/grpcio/grpc/aio/_server.py
@@ -17,12 +17,13 @@ from concurrent.futures import Executor
 from typing import Any, Optional, Sequence
 
 import grpc
-from grpc import _common, _compression
+from grpc import _common
+from grpc import _compression
 from grpc._cython import cygrpc
 
 from . import _base_server
-from ._typing import ChannelArgumentType
 from ._interceptor import ServerInterceptor
+from ._typing import ChannelArgumentType
 
 
 def _augment_channel_arguments(base_options: ChannelArgumentType,

--- a/src/python/grpcio/grpc/aio/_typing.py
+++ b/src/python/grpcio/grpc/aio/_typing.py
@@ -17,7 +17,10 @@ from typing import (Any, AsyncIterable, Callable, Iterable, Sequence, Tuple,
                     TypeVar, Union)
 
 from grpc._cython.cygrpc import EOF
-from ._metadata import Metadata, MetadataKey, MetadataValue
+
+from ._metadata import Metadata
+from ._metadata import MetadataKey
+from ._metadata import MetadataValue
 
 RequestType = TypeVar('RequestType')
 ResponseType = TypeVar('ResponseType')

--- a/src/python/grpcio/grpc/beta/implementations.py
+++ b/src/python/grpcio/grpc/beta/implementations.py
@@ -25,7 +25,8 @@ from grpc.beta import _metadata
 from grpc.beta import _server_adaptations
 from grpc.beta import interfaces  # pylint: disable=unused-import
 from grpc.framework.common import cardinality  # pylint: disable=unused-import
-from grpc.framework.interfaces.face import face  # pylint: disable=unused-import
+from grpc.framework.interfaces.face import \
+    face  # pylint: disable=unused-import
 
 # pylint: disable=too-many-arguments
 

--- a/src/python/grpcio/grpc/beta/interfaces.py
+++ b/src/python/grpcio/grpc/beta/interfaces.py
@@ -15,9 +15,8 @@
 
 import abc
 
-import six
-
 import grpc
+import six
 
 ChannelConnectivity = grpc.ChannelConnectivity
 # FATAL_FAILURE was a Beta-API name for SHUTDOWN

--- a/src/python/grpcio/grpc/experimental/__init__.py
+++ b/src/python/grpcio/grpc/experimental/__init__.py
@@ -121,5 +121,8 @@ __all__ = (
 )
 
 if sys.version_info > (3, 6):
-    from grpc._simple_stubs import unary_unary, unary_stream, stream_unary, stream_stream
+    from grpc._simple_stubs import stream_stream
+    from grpc._simple_stubs import stream_unary
+    from grpc._simple_stubs import unary_stream
+    from grpc._simple_stubs import unary_unary
     __all__ = __all__ + (unary_unary, unary_stream, stream_unary, stream_stream)

--- a/src/python/grpcio/grpc/framework/foundation/logging_pool.py
+++ b/src/python/grpcio/grpc/framework/foundation/logging_pool.py
@@ -13,9 +13,8 @@
 # limitations under the License.
 """A thread pool that logs exceptions raised by tasks executed within it."""
 
-import logging
-
 from concurrent import futures
+import logging
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/src/python/grpcio/grpc/framework/interfaces/base/base.py
+++ b/src/python/grpcio/grpc/framework/interfaces/base/base.py
@@ -28,9 +28,6 @@ import threading  # pylint: disable=unused-import
 
 import six
 
-# abandonment is referenced from specification in this module.
-from grpc.framework.foundation import abandonment  # pylint: disable=unused-import
-
 # pylint: disable=too-many-arguments
 
 

--- a/src/python/grpcio/grpc/framework/interfaces/face/face.py
+++ b/src/python/grpcio/grpc/framework/interfaces/face/face.py
@@ -17,15 +17,13 @@ import abc
 import collections
 import enum
 
-import six
-
 # cardinality, style, abandonment, future, and stream are
 # referenced from specification in this module.
 from grpc.framework.common import cardinality  # pylint: disable=unused-import
 from grpc.framework.common import style  # pylint: disable=unused-import
-from grpc.framework.foundation import abandonment  # pylint: disable=unused-import
 from grpc.framework.foundation import future  # pylint: disable=unused-import
 from grpc.framework.foundation import stream  # pylint: disable=unused-import
+import six
 
 # pylint: disable=too-many-arguments
 

--- a/src/python/grpcio/support.py
+++ b/src/python/grpcio/support.py
@@ -12,13 +12,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from distutils import errors
 import os
 import os.path
 import shutil
 import sys
 import tempfile
-
-from distutils import errors
 
 import commands
 

--- a/src/python/grpcio_admin/grpc_admin/__init__.py
+++ b/src/python/grpcio_admin/grpc_admin/__init__.py
@@ -13,8 +13,8 @@
 # limitations under the License.
 """gRPC Python's Admin interface."""
 
-import grpc_csds
 from grpc_channelz.v1 import channelz
+import grpc_csds
 
 
 def add_admin_servicers(server):

--- a/src/python/grpcio_channelz/grpc_channelz/v1/_async.py
+++ b/src/python/grpcio_channelz/grpc_channelz/v1/_async.py
@@ -14,10 +14,10 @@
 """AsyncIO version of Channelz servicer."""
 
 from grpc.experimental import aio
-
+from grpc_channelz.v1._servicer import \
+    ChannelzServicer as _SyncChannelzServicer
 import grpc_channelz.v1.channelz_pb2 as _channelz_pb2
 import grpc_channelz.v1.channelz_pb2_grpc as _channelz_pb2_grpc
-from grpc_channelz.v1._servicer import ChannelzServicer as _SyncChannelzServicer
 
 
 class ChannelzServicer(_channelz_pb2_grpc.ChannelzServicer):

--- a/src/python/grpcio_channelz/grpc_channelz/v1/_servicer.py
+++ b/src/python/grpcio_channelz/grpc_channelz/v1/_servicer.py
@@ -13,13 +13,11 @@
 # limitations under the License.
 """Channelz debug service implementation in gRPC Python."""
 
+from google.protobuf import json_format
 import grpc
 from grpc._cython import cygrpc
-
 import grpc_channelz.v1.channelz_pb2 as _channelz_pb2
 import grpc_channelz.v1.channelz_pb2_grpc as _channelz_pb2_grpc
-
-from google.protobuf import json_format
 
 
 class ChannelzServicer(_channelz_pb2_grpc.ChannelzServicer):

--- a/src/python/grpcio_channelz/grpc_channelz/v1/channelz.py
+++ b/src/python/grpcio_channelz/grpc_channelz/v1/channelz.py
@@ -14,10 +14,10 @@
 """Channelz debug service implementation in gRPC Python."""
 
 import sys
-import grpc
 
-import grpc_channelz.v1.channelz_pb2_grpc as _channelz_pb2_grpc
+import grpc
 from grpc_channelz.v1._servicer import ChannelzServicer
+import grpc_channelz.v1.channelz_pb2_grpc as _channelz_pb2_grpc
 
 _add_channelz_servicer_doc = """Add Channelz servicer to a server.
 

--- a/src/python/grpcio_channelz/setup.py
+++ b/src/python/grpcio_channelz/setup.py
@@ -68,6 +68,7 @@ INSTALL_REQUIRES = (
 
 try:
     import channelz_commands as _channelz_commands
+
     # we are in the build environment, otherwise the above import fails
     SETUP_REQUIRES = ('grpcio-tools=={version}'.format(
         version=grpc_version.VERSION),)

--- a/src/python/grpcio_csds/grpc_csds/__init__.py
+++ b/src/python/grpcio_csds/grpc_csds/__init__.py
@@ -13,13 +13,15 @@
 # limitations under the License.
 """Channelz debug service implementation in gRPC Python."""
 
+from google.protobuf import json_format
 from grpc._cython import cygrpc
 
-from google.protobuf import json_format
 try:
-    from envoy.service.status.v3 import csds_pb2, csds_pb2_grpc
+    from envoy.service.status.v3 import csds_pb2
+    from envoy.service.status.v3 import csds_pb2_grpc
 except ImportError:
-    from src.proto.grpc.testing.xds.v3 import csds_pb2, csds_pb2_grpc
+    from src.proto.grpc.testing.xds.v3 import csds_pb2
+    from src.proto.grpc.testing.xds.v3 import csds_pb2_grpc
 
 
 class ClientStatusDiscoveryServiceServicer(

--- a/src/python/grpcio_health_checking/grpc_health/v1/_async.py
+++ b/src/python/grpcio_health_checking/grpc_health/v1/_async.py
@@ -16,8 +16,8 @@
 import asyncio
 import collections
 from typing import MutableMapping
-import grpc
 
+import grpc
 from grpc_health.v1 import health_pb2 as _health_pb2
 from grpc_health.v1 import health_pb2_grpc as _health_pb2_grpc
 

--- a/src/python/grpcio_health_checking/grpc_health/v1/health.py
+++ b/src/python/grpcio_health_checking/grpc_health/v1/health.py
@@ -14,10 +14,10 @@
 """Reference implementation for health checking in gRPC Python."""
 
 import collections
-import threading
 import sys
-import grpc
+import threading
 
+import grpc
 from grpc_health.v1 import health_pb2 as _health_pb2
 from grpc_health.v1 import health_pb2_grpc as _health_pb2_grpc
 

--- a/src/python/grpcio_health_checking/setup.py
+++ b/src/python/grpcio_health_checking/setup.py
@@ -67,6 +67,7 @@ INSTALL_REQUIRES = (
 
 try:
     import health_commands as _health_commands
+
     # we are in the build environment, otherwise the above import fails
     SETUP_REQUIRES = ('grpcio-tools=={version}'.format(
         version=grpc_version.VERSION),)

--- a/src/python/grpcio_reflection/grpc_reflection/v1alpha/_async.py
+++ b/src/python/grpcio_reflection/grpc_reflection/v1alpha/_async.py
@@ -16,7 +16,6 @@
 from typing import AsyncIterable
 
 import grpc
-
 from grpc_reflection.v1alpha import reflection_pb2 as _reflection_pb2
 from grpc_reflection.v1alpha._base import BaseReflectionServicer
 

--- a/src/python/grpcio_reflection/grpc_reflection/v1alpha/_base.py
+++ b/src/python/grpcio_reflection/grpc_reflection/v1alpha/_base.py
@@ -13,10 +13,9 @@
 # limitations under the License.
 """Base implementation of reflection servicer."""
 
-import grpc
 from google.protobuf import descriptor_pb2
 from google.protobuf import descriptor_pool
-
+import grpc
 from grpc_reflection.v1alpha import reflection_pb2 as _reflection_pb2
 from grpc_reflection.v1alpha import reflection_pb2_grpc as _reflection_pb2_grpc
 

--- a/src/python/grpcio_reflection/grpc_reflection/v1alpha/reflection.py
+++ b/src/python/grpcio_reflection/grpc_reflection/v1alpha/reflection.py
@@ -14,11 +14,10 @@
 """Reference implementation for reflection in gRPC Python."""
 
 import sys
-import grpc
 
+import grpc
 from grpc_reflection.v1alpha import reflection_pb2 as _reflection_pb2
 from grpc_reflection.v1alpha import reflection_pb2_grpc as _reflection_pb2_grpc
-
 from grpc_reflection.v1alpha._base import BaseReflectionServicer
 
 SERVICE_NAME = _reflection_pb2.DESCRIPTOR.services_by_name[
@@ -64,8 +63,9 @@ Args:
 
 if sys.version_info[0] >= 3 and sys.version_info[1] >= 6:
     # Exposes AsyncReflectionServicer as public API.
-    from . import _async as aio
     from grpc.experimental import aio as grpc_aio  # pylint: disable=ungrouped-imports
+
+    from . import _async as aio
 
     def enable_server_reflection(service_names, server, pool=None):
         if isinstance(server, grpc_aio.Server):

--- a/src/python/grpcio_reflection/setup.py
+++ b/src/python/grpcio_reflection/setup.py
@@ -68,6 +68,7 @@ INSTALL_REQUIRES = (
 
 try:
     import reflection_commands as _reflection_commands
+
     # we are in the build environment, otherwise the above import fails
     SETUP_REQUIRES = ('grpcio-tools=={version}'.format(
         version=grpc_version.VERSION),)

--- a/src/python/grpcio_status/grpc_status/_async.py
+++ b/src/python/grpcio_status/grpc_status/_async.py
@@ -13,11 +13,11 @@
 # limitations under the License.
 """Reference implementation for status mapping in gRPC Python."""
 
+from google.rpc import status_pb2
 from grpc.experimental import aio
 
-from google.rpc import status_pb2
-
-from ._common import code_to_grpc_status_code, GRPC_DETAILS_METADATA_KEY
+from ._common import GRPC_DETAILS_METADATA_KEY
+from ._common import code_to_grpc_status_code
 
 
 async def from_call(call: aio.Call):

--- a/src/python/grpcio_status/grpc_status/rpc_status.py
+++ b/src/python/grpcio_status/grpc_status/rpc_status.py
@@ -16,10 +16,11 @@
 import collections
 import sys
 
+from google.rpc import status_pb2
 import grpc
 
-from google.rpc import status_pb2
-from ._common import code_to_grpc_status_code, GRPC_DETAILS_METADATA_KEY
+from ._common import GRPC_DETAILS_METADATA_KEY
+from ._common import code_to_grpc_status_code
 
 
 class _Status(

--- a/src/python/grpcio_status/setup.py
+++ b/src/python/grpcio_status/setup.py
@@ -68,6 +68,7 @@ INSTALL_REQUIRES = (
 
 try:
     import status_commands as _status_commands
+
     # we are in the build environment, otherwise the above import fails
     COMMAND_CLASS = {
         # Run preprocess from the repository *before* doing any packaging!

--- a/src/python/grpcio_testing/grpc_testing/__init__.py
+++ b/src/python/grpcio_testing/grpc_testing/__init__.py
@@ -14,11 +14,10 @@
 """Objects for use in testing gRPC Python-using application code."""
 
 import abc
-import six
 
 from google.protobuf import descriptor
-
 import grpc
+import six
 
 
 class UnaryUnaryChannelRpc(six.with_metaclass(abc.ABCMeta)):

--- a/src/python/grpcio_testing/grpc_testing/_server/_service.py
+++ b/src/python/grpcio_testing/grpc_testing/_server/_service.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 import copy
+
 import grpc
 
 

--- a/src/python/grpcio_testing/setup.py
+++ b/src/python/grpcio_testing/setup.py
@@ -55,6 +55,7 @@ INSTALL_REQUIRES = (
 
 try:
     import testing_commands as _testing_commands
+
     # we are in the build environment, otherwise the above import fails
     COMMAND_CLASS = {
         # Run preprocess from the repository *before* doing any packaging!

--- a/src/python/grpcio_tests/commands.py
+++ b/src/python/grpcio_tests/commands.py
@@ -248,9 +248,9 @@ class TestGevent(setuptools.Command):
         from gevent import monkey
         monkey.patch_all()
 
-        import tests
-
         import grpc.experimental.gevent
+
+        import tests
         grpc.experimental.gevent.init_gevent()
 
         import gevent
@@ -308,6 +308,7 @@ class RunInterop(test.test):
         # edit the Python system path.
         if self.use_asyncio:
             import asyncio
+
             from tests_aio.interop import server
             sys.argv[1:] = self.args.split()
             asyncio.get_event_loop().run_until_complete(server.serve())

--- a/src/python/grpcio_tests/setup.py
+++ b/src/python/grpcio_tests/setup.py
@@ -18,9 +18,8 @@ import os
 import os.path
 import sys
 
-import setuptools
-
 import grpc_tools.command
+import setuptools
 
 PY3 = sys.version_info.major == 3
 

--- a/src/python/grpcio_tests/tests/admin/test_admin.py
+++ b/src/python/grpcio_tests/tests/admin/test_admin.py
@@ -13,14 +13,16 @@
 # limitations under the License.
 """A test to ensure that admin services are registered correctly."""
 
+from concurrent.futures import ThreadPoolExecutor
 import logging
 import unittest
-from concurrent.futures import ThreadPoolExecutor
 
 import grpc
 import grpc_admin
-from grpc_csds import csds_pb2, csds_pb2_grpc
-from grpc_channelz.v1 import channelz_pb2, channelz_pb2_grpc
+from grpc_channelz.v1 import channelz_pb2
+from grpc_channelz.v1 import channelz_pb2_grpc
+from grpc_csds import csds_pb2
+from grpc_csds import csds_pb2_grpc
 
 
 class TestAdmin(unittest.TestCase):

--- a/src/python/grpcio_tests/tests/channelz/_channelz_servicer_test.py
+++ b/src/python/grpcio_tests/tests/channelz/_channelz_servicer_test.py
@@ -13,12 +13,10 @@
 # limitations under the License.
 """Tests of grpc_channelz.v1.channelz."""
 
+from concurrent import futures
 import unittest
 
-from concurrent import futures
-
 import grpc
-
 from grpc_channelz.v1 import channelz
 from grpc_channelz.v1 import channelz_pb2
 from grpc_channelz.v1 import channelz_pb2_grpc

--- a/src/python/grpcio_tests/tests/csds/test_csds.py
+++ b/src/python/grpcio_tests/tests/csds/test_csds.py
@@ -13,21 +13,23 @@
 # limitations under the License.
 """A simple test to ensure that the Python wrapper can get xDS config."""
 
+from concurrent.futures import ThreadPoolExecutor
 import logging
 import os
 import time
-from six.moves import queue
 import unittest
-from concurrent.futures import ThreadPoolExecutor
-
-import grpc
-import grpc_csds
 
 from google.protobuf import json_format
+import grpc
+import grpc_csds
+from six.moves import queue
+
 try:
-    from envoy.service.status.v3 import csds_pb2, csds_pb2_grpc
+    from envoy.service.status.v3 import csds_pb2
+    from envoy.service.status.v3 import csds_pb2_grpc
 except ImportError:
-    from src.proto.grpc.testing.xds.v3 import csds_pb2, csds_pb2_grpc
+    from src.proto.grpc.testing.xds.v3 import csds_pb2
+    from src.proto.grpc.testing.xds.v3 import csds_pb2_grpc
 
 _DUMMY_XDS_ADDRESS = 'xds:///foo.bar'
 _DUMMY_BOOTSTRAP_FILE = """

--- a/src/python/grpcio_tests/tests/fork/_fork_interop_test.py
+++ b/src/python/grpcio_tests/tests/fork/_fork_interop_test.py
@@ -13,13 +13,15 @@
 # limitations under the License.
 """Client-side fork interop tests as a unit test."""
 
-import six
 import subprocess
 import sys
 import tempfile
 import threading
 import unittest
+
 from grpc._cython import cygrpc
+import six
+
 from tests.fork import methods
 
 # New instance of multiprocessing.Process using fork without exec can and will

--- a/src/python/grpcio_tests/tests/fork/methods.py
+++ b/src/python/grpcio_tests/tests/fork/methods.py
@@ -22,7 +22,6 @@ import threading
 import time
 
 import grpc
-
 from six.moves import queue
 
 from src.proto.grpc.testing import empty_pb2

--- a/src/python/grpcio_tests/tests/health_check/_health_servicer_test.py
+++ b/src/python/grpcio_tests/tests/health_check/_health_servicer_test.py
@@ -19,16 +19,14 @@ import time
 import unittest
 
 import grpc
-
 from grpc_health.v1 import health
 from grpc_health.v1 import health_pb2
 from grpc_health.v1 import health_pb2_grpc
+from six.moves import queue
 
 from tests.unit import test_common
 from tests.unit import thread_pool
 from tests.unit.framework.common import test_constants
-
-from six.moves import queue
 
 _SERVING_SERVICE = 'grpc.test.TestServiceServing'
 _UNKNOWN_SERVICE = 'grpc.test.TestServiceUnknown'

--- a/src/python/grpcio_tests/tests/http2/negative_http2_client.py
+++ b/src/python/grpcio_tests/tests/http2/negative_http2_client.py
@@ -14,11 +14,12 @@
 """The Python client used to test negative http2 conditions."""
 
 import argparse
+import time
 
 import grpc
-import time
-from src.proto.grpc.testing import test_pb2_grpc
+
 from src.proto.grpc.testing import messages_pb2
+from src.proto.grpc.testing import test_pb2_grpc
 
 
 def _validate_payload_type_and_length(response, expected_type, expected_length):

--- a/src/python/grpcio_tests/tests/interop/_insecure_intraop_test.py
+++ b/src/python/grpcio_tests/tests/interop/_insecure_intraop_test.py
@@ -16,11 +16,11 @@
 import unittest
 
 import grpc
-from src.proto.grpc.testing import test_pb2_grpc
 
+from src.proto.grpc.testing import test_pb2_grpc
 from tests.interop import _intraop_test_case
-from tests.interop import service
 from tests.interop import server
+from tests.interop import service
 from tests.unit import test_common
 
 

--- a/src/python/grpcio_tests/tests/interop/_secure_intraop_test.py
+++ b/src/python/grpcio_tests/tests/interop/_secure_intraop_test.py
@@ -16,11 +16,11 @@
 import unittest
 
 import grpc
-from src.proto.grpc.testing import test_pb2_grpc
 
+from src.proto.grpc.testing import test_pb2_grpc
 from tests.interop import _intraop_test_case
-from tests.interop import service
 from tests.interop import resources
+from tests.interop import service
 from tests.unit import test_common
 
 _SERVER_HOST_OVERRIDE = 'foo.test.google.fr'

--- a/src/python/grpcio_tests/tests/interop/client.py
+++ b/src/python/grpcio_tests/tests/interop/client.py
@@ -19,8 +19,8 @@ import os
 from google import auth as google_auth
 from google.auth import jwt as google_auth_jwt
 import grpc
-from src.proto.grpc.testing import test_pb2_grpc
 
+from src.proto.grpc.testing import test_pb2_grpc
 from tests.interop import methods
 from tests.interop import resources
 

--- a/src/python/grpcio_tests/tests/interop/resources.py
+++ b/src/python/grpcio_tests/tests/interop/resources.py
@@ -14,8 +14,8 @@
 """Constants and functions for data used in interoperability testing."""
 
 import argparse
-import pkgutil
 import os
+import pkgutil
 
 _ROOT_CERTIFICATES_RESOURCE_PATH = 'credentials/ca.pem'
 _PRIVATE_KEY_RESOURCE_PATH = 'credentials/server1.key'

--- a/src/python/grpcio_tests/tests/interop/server.py
+++ b/src/python/grpcio_tests/tests/interop/server.py
@@ -18,10 +18,10 @@ from concurrent import futures
 import logging
 
 import grpc
-from src.proto.grpc.testing import test_pb2_grpc
 
-from tests.interop import service
+from src.proto.grpc.testing import test_pb2_grpc
 from tests.interop import resources
+from tests.interop import service
 from tests.unit import test_common
 
 logging.basicConfig()

--- a/src/python/grpcio_tests/tests/protoc_plugin/_python_plugin_test.py
+++ b/src/python/grpcio_tests/tests/protoc_plugin/_python_plugin_test.py
@@ -24,17 +24,16 @@ import tempfile
 import threading
 import unittest
 
-from six import moves
-
 import grpc
 import grpc.experimental
-from tests.unit import test_common
-from tests.unit.framework.common import test_constants
+from six import moves
 
 import tests.protoc_plugin.protos.payload.test_payload_pb2 as payload_pb2
 import tests.protoc_plugin.protos.requests.r.test_requests_pb2 as request_pb2
 import tests.protoc_plugin.protos.responses.test_responses_pb2 as response_pb2
 import tests.protoc_plugin.protos.service.test_service_pb2_grpc as service_pb2_grpc
+from tests.unit import test_common
+from tests.unit.framework.common import test_constants
 
 # Identifiers of entities we expect to find in the generated module.
 STUB_IDENTIFIER = 'TestServiceStub'

--- a/src/python/grpcio_tests/tests/protoc_plugin/_split_definitions_test.py
+++ b/src/python/grpcio_tests/tests/protoc_plugin/_split_definitions_test.py
@@ -24,10 +24,10 @@ import sys
 import tempfile
 import unittest
 
-import six
-
 import grpc
 from grpc_tools import protoc
+import six
+
 from tests.unit import test_common
 
 _MESSAGES_IMPORT = b'import "messages.proto";'

--- a/src/python/grpcio_tests/tests/protoc_plugin/beta_python_plugin_test.py
+++ b/src/python/grpcio_tests/tests/protoc_plugin/beta_python_plugin_test.py
@@ -23,13 +23,13 @@ import tempfile
 import threading
 import unittest
 
-from six import moves
-
 from grpc.beta import implementations
 from grpc.beta import interfaces
 from grpc.framework.foundation import future
 from grpc.framework.interfaces.face import face
 from grpc_tools import protoc
+from six import moves
+
 from tests.unit.framework.common import test_constants
 
 _RELATIVE_PROTO_PATH = 'relative_proto_path'

--- a/src/python/grpcio_tests/tests/qps/benchmark_client.py
+++ b/src/python/grpcio_tests/tests/qps/benchmark_client.py
@@ -14,15 +14,15 @@
 """Defines test client behaviors (UNARY/STREAMING) (SYNC/ASYNC)."""
 
 import abc
+from concurrent import futures
 import threading
 import time
 
-from concurrent import futures
+import grpc
 from six.moves import queue
 
-import grpc
-from src.proto.grpc.testing import messages_pb2
 from src.proto.grpc.testing import benchmark_service_pb2_grpc
+from src.proto.grpc.testing import messages_pb2
 from tests.unit import resources
 from tests.unit import test_common
 

--- a/src/python/grpcio_tests/tests/qps/benchmark_server.py
+++ b/src/python/grpcio_tests/tests/qps/benchmark_server.py
@@ -12,8 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from src.proto.grpc.testing import messages_pb2
 from src.proto.grpc.testing import benchmark_service_pb2_grpc
+from src.proto.grpc.testing import messages_pb2
 
 
 class BenchmarkServer(benchmark_service_pb2_grpc.BenchmarkServiceServicer):

--- a/src/python/grpcio_tests/tests/qps/qps_worker.py
+++ b/src/python/grpcio_tests/tests/qps/qps_worker.py
@@ -18,8 +18,8 @@ import logging
 import time
 
 import grpc
-from src.proto.grpc.testing import worker_service_pb2_grpc
 
+from src.proto.grpc.testing import worker_service_pb2_grpc
 from tests.qps import worker_server
 from tests.unit import test_common
 

--- a/src/python/grpcio_tests/tests/qps/worker_server.py
+++ b/src/python/grpcio_tests/tests/qps/worker_server.py
@@ -12,18 +12,18 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from concurrent import futures
 import multiprocessing
 import random
 import threading
 import time
 
-from concurrent import futures
 import grpc
-from src.proto.grpc.testing import control_pb2
-from src.proto.grpc.testing import benchmark_service_pb2_grpc
-from src.proto.grpc.testing import worker_service_pb2_grpc
-from src.proto.grpc.testing import stats_pb2
 
+from src.proto.grpc.testing import benchmark_service_pb2_grpc
+from src.proto.grpc.testing import control_pb2
+from src.proto.grpc.testing import stats_pb2
+from src.proto.grpc.testing import worker_service_pb2_grpc
 from tests.qps import benchmark_client
 from tests.qps import benchmark_server
 from tests.qps import client_runner

--- a/src/python/grpcio_tests/tests/reflection/_reflection_servicer_test.py
+++ b/src/python/grpcio_tests/tests/reflection/_reflection_servicer_test.py
@@ -15,18 +15,15 @@
 
 import unittest
 
+from google.protobuf import descriptor_pb2
+from google.protobuf import descriptor_pool
 import grpc
-
 from grpc_reflection.v1alpha import reflection
 from grpc_reflection.v1alpha import reflection_pb2
 from grpc_reflection.v1alpha import reflection_pb2_grpc
 
-from google.protobuf import descriptor_pool
-from google.protobuf import descriptor_pb2
-
 from src.proto.grpc.testing import empty_pb2
 from src.proto.grpc.testing.proto2 import empty2_extensions_pb2
-
 from tests.unit import test_common
 
 _EMPTY_PROTO_FILE_NAME = 'src/proto/grpc/testing/empty.proto'

--- a/src/python/grpcio_tests/tests/status/_grpc_status_test.py
+++ b/src/python/grpcio_tests/tests/status/_grpc_status_test.py
@@ -11,7 +11,10 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-"""Tests of grpc_status."""
+"""Tests of grpc_status.
+
+isort:skip_file
+"""
 
 # NOTE(lidiz) This module only exists in Bazel BUILD file, for more details
 # please refer to comments in the "bazel_namespace_package_hack" module.

--- a/src/python/grpcio_tests/tests/stress/client.py
+++ b/src/python/grpcio_tests/tests/stress/client.py
@@ -19,9 +19,9 @@ import threading
 
 import grpc
 from six.moves import queue
+
 from src.proto.grpc.testing import metrics_pb2_grpc
 from src.proto.grpc.testing import test_pb2_grpc
-
 from tests.interop import methods
 from tests.interop import resources
 from tests.qps import histogram

--- a/src/python/grpcio_tests/tests/stress/unary_stream_benchmark.py
+++ b/src/python/grpcio_tests/tests/stress/unary_stream_benchmark.py
@@ -12,14 +12,15 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import contextlib
 import datetime
-import threading
-import grpc
-import grpc.experimental
 import subprocess
 import sys
+import threading
 import time
-import contextlib
+
+import grpc
+import grpc.experimental
 
 _PORT = 5741
 _MESSAGE_SIZE = 4
@@ -49,8 +50,9 @@ server.wait_for_termination()
 """ % _PORT
 
 try:
+    from src.python.grpcio_tests.tests.stress import \
+        unary_stream_benchmark_pb2_grpc
     from src.python.grpcio_tests.tests.stress import unary_stream_benchmark_pb2
-    from src.python.grpcio_tests.tests.stress import unary_stream_benchmark_pb2_grpc
 
     _GRPC_CHANNEL_OPTIONS = [
         ('grpc.max_metadata_size', 16 * 1024 * 1024),

--- a/src/python/grpcio_tests/tests/testing/_client_application.py
+++ b/src/python/grpcio_tests/tests/testing/_client_application.py
@@ -19,13 +19,12 @@ import threading
 import time
 
 import grpc
-from tests.unit.framework.common import test_constants
 
+from tests.testing import _application_common
 from tests.testing.proto import requests_pb2
 from tests.testing.proto import services_pb2
 from tests.testing.proto import services_pb2_grpc
-
-from tests.testing import _application_common
+from tests.unit.framework.common import test_constants
 
 
 @enum.unique

--- a/src/python/grpcio_tests/tests/testing/_client_test.py
+++ b/src/python/grpcio_tests/tests/testing/_client_test.py
@@ -18,7 +18,6 @@ import unittest
 
 import grpc
 from grpc.framework.foundation import logging_pool
-from tests.unit.framework.common import test_constants
 import grpc_testing
 
 from tests.testing import _application_common
@@ -26,6 +25,7 @@ from tests.testing import _application_testing_common
 from tests.testing import _client_application
 from tests.testing.proto import requests_pb2
 from tests.testing.proto import services_pb2
+from tests.unit.framework.common import test_constants
 
 
 # TODO(https://github.com/google/protobuf/issues/3452): Drop this skip.

--- a/src/python/grpcio_tests/tests/testing/_server_application.py
+++ b/src/python/grpcio_tests/tests/testing/_server_application.py
@@ -13,9 +13,9 @@
 # limitations under the License.
 """An example gRPC Python-using server-side application."""
 
-import grpc
-
 import threading
+
+import grpc
 
 # requests_pb2 is a semantic dependency of this module.
 from tests.testing import _application_common

--- a/src/python/grpcio_tests/tests/unit/_abort_test.py
+++ b/src/python/grpcio_tests/tests/unit/_abort_test.py
@@ -13,10 +13,10 @@
 # limitations under the License.
 """Tests server context abort mechanism"""
 
-import unittest
 import collections
 import gc
 import logging
+import unittest
 import weakref
 
 import grpc

--- a/src/python/grpcio_tests/tests/unit/_api_test.py
+++ b/src/python/grpcio_tests/tests/unit/_api_test.py
@@ -13,12 +13,11 @@
 # limitations under the License.
 """Test of gRPC Python's application-layer API."""
 
-import unittest
 import logging
-
-import six
+import unittest
 
 import grpc
+import six
 
 from tests.unit import _from_grpc_import_star
 

--- a/src/python/grpcio_tests/tests/unit/_auth_context_test.py
+++ b/src/python/grpcio_tests/tests/unit/_auth_context_test.py
@@ -13,17 +13,17 @@
 # limitations under the License.
 """Tests exposure of SSL auth context"""
 
+import logging
 import pickle
 import unittest
-import logging
 
 import grpc
 from grpc import _channel
 from grpc.experimental import session_cache
 import six
 
-from tests.unit import test_common
 from tests.unit import resources
+from tests.unit import test_common
 
 _REQUEST = b'\x00\x00\x00'
 _RESPONSE = b'\x00\x00\x00'

--- a/src/python/grpcio_tests/tests/unit/_auth_test.py
+++ b/src/python/grpcio_tests/tests/unit/_auth_test.py
@@ -14,9 +14,9 @@
 """Tests of standard AuthMetadataPlugins."""
 
 import collections
+import logging
 import threading
 import unittest
-import logging
 
 from grpc import _auth
 

--- a/src/python/grpcio_tests/tests/unit/_channel_args_test.py
+++ b/src/python/grpcio_tests/tests/unit/_channel_args_test.py
@@ -14,8 +14,8 @@
 """Tests of channel arguments on client/server side."""
 
 from concurrent import futures
-import unittest
 import logging
+import unittest
 
 import grpc
 

--- a/src/python/grpcio_tests/tests/unit/_channel_connectivity_test.py
+++ b/src/python/grpcio_tests/tests/unit/_channel_connectivity_test.py
@@ -19,8 +19,9 @@ import time
 import unittest
 
 import grpc
-from tests.unit.framework.common import test_constants
+
 from tests.unit import thread_pool
+from tests.unit.framework.common import test_constants
 
 
 def _ready_in_connectivities(connectivities):

--- a/src/python/grpcio_tests/tests/unit/_channel_ready_future_test.py
+++ b/src/python/grpcio_tests/tests/unit/_channel_ready_future_test.py
@@ -13,13 +13,14 @@
 # limitations under the License.
 """Tests of grpc.channel_ready_future."""
 
+import logging
 import threading
 import unittest
-import logging
 
 import grpc
-from tests.unit.framework.common import test_constants
+
 from tests.unit import thread_pool
+from tests.unit.framework.common import test_constants
 
 
 class _Callback(object):

--- a/src/python/grpcio_tests/tests/unit/_compression_test.py
+++ b/src/python/grpcio_tests/tests/unit/_compression_test.py
@@ -13,21 +13,20 @@
 # limitations under the License.
 """Tests server and client side compression."""
 
-import unittest
-
-import contextlib
 from concurrent import futures
+import contextlib
 import functools
 import itertools
 import logging
 import os
+import unittest
 
 import grpc
 from grpc import _grpcio_metadata
 
+from tests.unit import _tcp_proxy
 from tests.unit import test_common
 from tests.unit.framework.common import test_constants
-from tests.unit import _tcp_proxy
 
 _UNARY_UNARY = '/test/UnaryUnary'
 _UNARY_STREAM = '/test/UnaryStream'

--- a/src/python/grpcio_tests/tests/unit/_contextvars_propagation_test.py
+++ b/src/python/grpcio_tests/tests/unit/_contextvars_propagation_test.py
@@ -21,9 +21,9 @@ import threading
 import unittest
 
 import grpc
+from six.moves import queue
 
 from tests.unit import test_common
-from six.moves import queue
 
 _UNARY_UNARY = "/test/UnaryUnary"
 _REQUEST = b"0000"

--- a/src/python/grpcio_tests/tests/unit/_credentials_test.py
+++ b/src/python/grpcio_tests/tests/unit/_credentials_test.py
@@ -13,11 +13,11 @@
 # limitations under the License.
 """Tests of credentials."""
 
-import unittest
 import logging
-import six
+import unittest
 
 import grpc
+import six
 
 
 class CredentialsTest(unittest.TestCase):

--- a/src/python/grpcio_tests/tests/unit/_cython/_cancel_many_calls_test.py
+++ b/src/python/grpcio_tests/tests/unit/_cython/_cancel_many_calls_test.py
@@ -18,8 +18,9 @@ import unittest
 
 from grpc._cython import cygrpc
 from grpc.framework.foundation import logging_pool
-from tests.unit.framework.common import test_constants
+
 from tests.unit._cython import test_utilities
+from tests.unit.framework.common import test_constants
 
 _EMPTY_FLAGS = 0
 _EMPTY_METADATA = ()

--- a/src/python/grpcio_tests/tests/unit/_cython/_channel_test.py
+++ b/src/python/grpcio_tests/tests/unit/_cython/_channel_test.py
@@ -12,8 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import time
 import threading
+import time
 import unittest
 
 from grpc._cython import cygrpc

--- a/src/python/grpcio_tests/tests/unit/_cython/_read_some_but_not_all_responses_test.py
+++ b/src/python/grpcio_tests/tests/unit/_cython/_read_some_but_not_all_responses_test.py
@@ -17,6 +17,7 @@ import threading
 import unittest
 
 from grpc._cython import cygrpc
+
 from tests.unit._cython import test_utilities
 
 _EMPTY_FLAGS = 0

--- a/src/python/grpcio_tests/tests/unit/_cython/cygrpc_test.py
+++ b/src/python/grpcio_tests/tests/unit/_cython/cygrpc_test.py
@@ -12,15 +12,16 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import time
-import threading
-import unittest
 import platform
+import threading
+import time
+import unittest
 
 from grpc._cython import cygrpc
-from tests.unit._cython import test_utilities
-from tests.unit import test_common
+
 from tests.unit import resources
+from tests.unit import test_common
+from tests.unit._cython import test_utilities
 
 _SSL_HOST_OVERRIDE = b'foo.test.google.fr'
 _CALL_CREDENTIALS_METADATA_KEY = 'call-creds-key'

--- a/src/python/grpcio_tests/tests/unit/_dns_resolver_test.py
+++ b/src/python/grpcio_tests/tests/unit/_dns_resolver_test.py
@@ -13,11 +13,12 @@
 # limitations under the License.
 """Tests for an actual dns resolution."""
 
-import unittest
 import logging
-import six
+import unittest
 
 import grpc
+import six
+
 from tests.unit import test_common
 from tests.unit.framework.common import test_constants
 

--- a/src/python/grpcio_tests/tests/unit/_empty_message_test.py
+++ b/src/python/grpcio_tests/tests/unit/_empty_message_test.py
@@ -12,8 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import unittest
 import logging
+import unittest
 
 import grpc
 

--- a/src/python/grpcio_tests/tests/unit/_exit_scenarios.py
+++ b/src/python/grpcio_tests/tests/unit/_exit_scenarios.py
@@ -14,9 +14,9 @@
 """Defines a number of module-scope gRPC scenarios to test clean exit."""
 
 import argparse
+import logging
 import threading
 import time
-import logging
 
 import grpc
 

--- a/src/python/grpcio_tests/tests/unit/_exit_test.py
+++ b/src/python/grpcio_tests/tests/unit/_exit_test.py
@@ -18,16 +18,17 @@ test is considered successful if it doesn't freeze/timeout.
 """
 
 import atexit
+import datetime
+import logging
 import os
 import signal
-import six
 import subprocess
 import sys
 import threading
-import datetime
 import time
 import unittest
-import logging
+
+import six
 
 from tests.unit import _exit_scenarios
 

--- a/src/python/grpcio_tests/tests/unit/_grpc_shutdown_test.py
+++ b/src/python/grpcio_tests/tests/unit/_grpc_shutdown_test.py
@@ -13,10 +13,10 @@
 # limitations under the License.
 """Tests the gRPC Core shutdown path."""
 
-import time
-import threading
-import unittest
 import datetime
+import threading
+import time
+import unittest
 
 import grpc
 

--- a/src/python/grpcio_tests/tests/unit/_interceptor_test.py
+++ b/src/python/grpcio_tests/tests/unit/_interceptor_test.py
@@ -14,12 +14,12 @@
 """Test of gRPC Python interceptors."""
 
 import collections
+from concurrent import futures
 import itertools
-import threading
-import unittest
 import logging
 import os
-from concurrent import futures
+import threading
+import unittest
 
 import grpc
 from grpc.framework.foundation import logging_pool

--- a/src/python/grpcio_tests/tests/unit/_invalid_metadata_test.py
+++ b/src/python/grpcio_tests/tests/unit/_invalid_metadata_test.py
@@ -13,8 +13,8 @@
 # limitations under the License.
 """Test of RPCs made against gRPC Python's application-layer API."""
 
-import unittest
 import logging
+import unittest
 
 import grpc
 

--- a/src/python/grpcio_tests/tests/unit/_invocation_defects_test.py
+++ b/src/python/grpcio_tests/tests/unit/_invocation_defects_test.py
@@ -12,8 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import unittest
 import logging
+import unittest
 
 import grpc
 

--- a/src/python/grpcio_tests/tests/unit/_local_credentials_test.py
+++ b/src/python/grpcio_tests/tests/unit/_local_credentials_test.py
@@ -13,9 +13,10 @@
 # limitations under the License.
 """Test of RPCs made using local credentials."""
 
-import unittest
-import os
 from concurrent.futures import ThreadPoolExecutor
+import os
+import unittest
+
 import grpc
 
 

--- a/src/python/grpcio_tests/tests/unit/_logging_test.py
+++ b/src/python/grpcio_tests/tests/unit/_logging_test.py
@@ -13,11 +13,12 @@
 # limitations under the License.
 """Test of gRPC Python's interaction with the python logging module"""
 
-import unittest
 import logging
-import grpc
 import subprocess
 import sys
+import unittest
+
+import grpc
 
 INTERPRETER = sys.executable
 

--- a/src/python/grpcio_tests/tests/unit/_metadata_code_details_test.py
+++ b/src/python/grpcio_tests/tests/unit/_metadata_code_details_test.py
@@ -13,9 +13,9 @@
 # limitations under the License.
 """Tests application-provided metadata, status code, and details."""
 
+import logging
 import threading
 import unittest
-import logging
 
 import grpc
 

--- a/src/python/grpcio_tests/tests/unit/_metadata_flags_test.py
+++ b/src/python/grpcio_tests/tests/unit/_metadata_flags_test.py
@@ -13,20 +13,20 @@
 # limitations under the License.
 """Tests metadata flags feature by testing wait-for-ready semantics"""
 
-import time
-import weakref
-import unittest
-import threading
 import logging
 import socket
-from six.moves import queue
+import threading
+import time
+import unittest
+import weakref
 
 import grpc
+from six.moves import queue
 
 from tests.unit import test_common
-from tests.unit.framework.common import test_constants
 import tests.unit.framework.common
 from tests.unit.framework.common import get_socket
+from tests.unit.framework.common import test_constants
 
 _UNARY_UNARY = '/test/UnaryUnary'
 _UNARY_STREAM = '/test/UnaryStream'

--- a/src/python/grpcio_tests/tests/unit/_metadata_test.py
+++ b/src/python/grpcio_tests/tests/unit/_metadata_test.py
@@ -13,9 +13,9 @@
 # limitations under the License.
 """Tests server and client side metadata API."""
 
+import logging
 import unittest
 import weakref
-import logging
 
 import grpc
 from grpc import _channel

--- a/src/python/grpcio_tests/tests/unit/_reconnect_test.py
+++ b/src/python/grpcio_tests/tests/unit/_reconnect_test.py
@@ -13,16 +13,16 @@
 # limitations under the License.
 """Tests that a channel will reconnect if a connection is dropped"""
 
+import logging
 import socket
 import time
-import logging
 import unittest
 
 import grpc
 from grpc.framework.foundation import logging_pool
 
-from tests.unit.framework.common import test_constants
 from tests.unit.framework.common import bound_socket
+from tests.unit.framework.common import test_constants
 
 _REQUEST = b'\x00\x00\x00'
 _RESPONSE = b'\x00\x00\x01'

--- a/src/python/grpcio_tests/tests/unit/_resource_exhausted_test.py
+++ b/src/python/grpcio_tests/tests/unit/_resource_exhausted_test.py
@@ -13,9 +13,9 @@
 # limitations under the License.
 """Tests server responding with RESOURCE_EXHAUSTED."""
 
+import logging
 import threading
 import unittest
-import logging
 
 import grpc
 from grpc import _channel

--- a/src/python/grpcio_tests/tests/unit/_rpc_part_1_test.py
+++ b/src/python/grpcio_tests/tests/unit/_rpc_part_1_test.py
@@ -13,20 +13,26 @@
 # limitations under the License.
 """Test of RPCs made against gRPC Python's application-layer API."""
 
+from concurrent import futures
 import itertools
+import logging
 import threading
 import unittest
-import logging
-from concurrent import futures
 
 import grpc
 from grpc.framework.foundation import logging_pool
 
-from tests.unit._rpc_test_helpers import (
-    TIMEOUT_SHORT, Callback, unary_unary_multi_callable,
-    unary_stream_multi_callable, unary_stream_non_blocking_multi_callable,
-    stream_unary_multi_callable, stream_stream_multi_callable,
-    stream_stream_non_blocking_multi_callable, BaseRPCTest)
+from tests.unit._rpc_test_helpers import BaseRPCTest
+from tests.unit._rpc_test_helpers import Callback
+from tests.unit._rpc_test_helpers import TIMEOUT_SHORT
+from tests.unit._rpc_test_helpers import \
+    stream_stream_non_blocking_multi_callable
+from tests.unit._rpc_test_helpers import \
+    unary_stream_non_blocking_multi_callable
+from tests.unit._rpc_test_helpers import stream_stream_multi_callable
+from tests.unit._rpc_test_helpers import stream_unary_multi_callable
+from tests.unit._rpc_test_helpers import unary_stream_multi_callable
+from tests.unit._rpc_test_helpers import unary_unary_multi_callable
 from tests.unit.framework.common import test_constants
 
 

--- a/src/python/grpcio_tests/tests/unit/_rpc_part_2_test.py
+++ b/src/python/grpcio_tests/tests/unit/_rpc_part_2_test.py
@@ -13,20 +13,26 @@
 # limitations under the License.
 """Test of RPCs made against gRPC Python's application-layer API."""
 
+from concurrent import futures
 import itertools
+import logging
 import threading
 import unittest
-import logging
-from concurrent import futures
 
 import grpc
 from grpc.framework.foundation import logging_pool
 
-from tests.unit._rpc_test_helpers import (
-    TIMEOUT_SHORT, Callback, unary_unary_multi_callable,
-    unary_stream_multi_callable, unary_stream_non_blocking_multi_callable,
-    stream_unary_multi_callable, stream_stream_multi_callable,
-    stream_stream_non_blocking_multi_callable, BaseRPCTest)
+from tests.unit._rpc_test_helpers import BaseRPCTest
+from tests.unit._rpc_test_helpers import Callback
+from tests.unit._rpc_test_helpers import TIMEOUT_SHORT
+from tests.unit._rpc_test_helpers import \
+    stream_stream_non_blocking_multi_callable
+from tests.unit._rpc_test_helpers import \
+    unary_stream_non_blocking_multi_callable
+from tests.unit._rpc_test_helpers import stream_stream_multi_callable
+from tests.unit._rpc_test_helpers import stream_unary_multi_callable
+from tests.unit._rpc_test_helpers import unary_stream_multi_callable
+from tests.unit._rpc_test_helpers import unary_unary_multi_callable
 from tests.unit.framework.common import test_constants
 
 

--- a/src/python/grpcio_tests/tests/unit/_server_shutdown_scenarios.py
+++ b/src/python/grpcio_tests/tests/unit/_server_shutdown_scenarios.py
@@ -14,16 +14,16 @@
 """Defines a number of module-scope gRPC scenarios to test server shutdown."""
 
 import argparse
+from concurrent import futures
+import logging
 import os
 import threading
 import time
-import logging
 
 import grpc
-from tests.unit import test_common
-
-from concurrent import futures
 from six.moves import queue
+
+from tests.unit import test_common
 
 WAIT_TIME = 1000
 

--- a/src/python/grpcio_tests/tests/unit/_server_shutdown_test.py
+++ b/src/python/grpcio_tests/tests/unit/_server_shutdown_test.py
@@ -18,12 +18,12 @@ test is considered successful if it doesn't freeze/timeout.
 """
 
 import atexit
+import logging
 import os
 import subprocess
 import sys
 import threading
 import unittest
-import logging
 
 from tests.unit import _server_shutdown_scenarios
 

--- a/src/python/grpcio_tests/tests/unit/_server_ssl_cert_config_test.py
+++ b/src/python/grpcio_tests/tests/unit/_server_ssl_cert_config_test.py
@@ -31,20 +31,20 @@ Core by extension, support for server certificate rotation.
 
 import abc
 import collections
+from concurrent import futures
+import logging
 import os
-import six
 import threading
 import unittest
-import logging
-
-from concurrent import futures
 
 import grpc
-from tests.unit import resources
-from tests.unit import test_common
+import six
+
 from tests.testing import _application_common
 from tests.testing import _server_application
 from tests.testing.proto import services_pb2_grpc
+from tests.unit import resources
+from tests.unit import test_common
 
 CA_1_PEM = resources.cert_hier_1_root_ca_cert()
 CA_2_PEM = resources.cert_hier_2_root_ca_cert()

--- a/src/python/grpcio_tests/tests/unit/_server_test.py
+++ b/src/python/grpcio_tests/tests/unit/_server_test.py
@@ -13,8 +13,8 @@
 # limitations under the License.
 
 from concurrent import futures
-import unittest
 import logging
+import unittest
 
 import grpc
 

--- a/src/python/grpcio_tests/tests/unit/_server_wait_for_termination_test.py
+++ b/src/python/grpcio_tests/tests/unit/_server_wait_for_termination_test.py
@@ -14,14 +14,15 @@
 
 from __future__ import division
 
-import datetime
 from concurrent import futures
-import unittest
-import time
+import datetime
 import threading
-import six
+import time
+import unittest
 
 import grpc
+import six
+
 from tests.unit.framework.common import test_constants
 
 _WAIT_FOR_BLOCKING = datetime.timedelta(seconds=1)

--- a/src/python/grpcio_tests/tests/unit/_session_cache_test.py
+++ b/src/python/grpcio_tests/tests/unit/_session_cache_test.py
@@ -13,16 +13,16 @@
 # limitations under the License.
 """Tests experimental TLS Session Resumption API"""
 
+import logging
 import pickle
 import unittest
-import logging
 
 import grpc
 from grpc import _channel
 from grpc.experimental import session_cache
 
-from tests.unit import test_common
 from tests.unit import resources
+from tests.unit import test_common
 
 _REQUEST = b'\x00\x00\x00'
 _RESPONSE = b'\x00\x00\x00'

--- a/src/python/grpcio_tests/tests/unit/_signal_handling_test.py
+++ b/src/python/grpcio_tests/tests/unit/_signal_handling_test.py
@@ -17,15 +17,15 @@ import logging
 import os
 import signal
 import subprocess
+import sys
 import tempfile
 import threading
 import unittest
-import sys
 
 import grpc
 
-from tests.unit import test_common
 from tests.unit import _signal_client
+from tests.unit import test_common
 
 _CLIENT_PATH = None
 if sys.executable is not None:

--- a/src/python/grpcio_tests/tests/unit/_version_test.py
+++ b/src/python/grpcio_tests/tests/unit/_version_test.py
@@ -13,9 +13,10 @@
 # limitations under the License.
 """Test for grpc.__version__"""
 
-import unittest
-import grpc
 import logging
+import unittest
+
+import grpc
 from grpc import _grpcio_metadata
 
 

--- a/src/python/grpcio_tests/tests/unit/_xds_credentials_test.py
+++ b/src/python/grpcio_tests/tests/unit/_xds_credentials_test.py
@@ -13,16 +13,16 @@
 # limitations under the License.
 """Tests xDS server and channel credentials."""
 
-import unittest
-
-import logging
 from concurrent import futures
 import contextlib
+import logging
+import unittest
 
 import grpc
 import grpc.experimental
-from tests.unit import test_common
+
 from tests.unit import resources
+from tests.unit import test_common
 
 
 class _GenericHandler(grpc.GenericRpcHandler):

--- a/src/python/grpcio_tests/tests/unit/beta/_beta_features_test.py
+++ b/src/python/grpcio_tests/tests/unit/beta/_beta_features_test.py
@@ -20,6 +20,7 @@ from grpc.beta import implementations
 from grpc.beta import interfaces
 from grpc.framework.common import cardinality
 from grpc.framework.interfaces.face import utilities
+
 from tests.unit import resources
 from tests.unit.beta import test_utilities
 from tests.unit.framework.common import test_constants

--- a/src/python/grpcio_tests/tests/unit/beta/_implementations_test.py
+++ b/src/python/grpcio_tests/tests/unit/beta/_implementations_test.py
@@ -16,9 +16,9 @@
 import datetime
 import unittest
 
+from grpc.beta import implementations
 from oauth2client import client as oauth2client_client
 
-from grpc.beta import implementations
 from tests.unit import resources
 
 

--- a/src/python/grpcio_tests/tests/unit/beta/_not_found_test.py
+++ b/src/python/grpcio_tests/tests/unit/beta/_not_found_test.py
@@ -18,6 +18,7 @@ import unittest
 from grpc.beta import implementations
 from grpc.beta import interfaces
 from grpc.framework.interfaces.face import face
+
 from tests.unit.framework.common import test_constants
 
 

--- a/src/python/grpcio_tests/tests/unit/beta/_utilities_test.py
+++ b/src/python/grpcio_tests/tests/unit/beta/_utilities_test.py
@@ -20,6 +20,7 @@ import unittest
 from grpc.beta import implementations
 from grpc.beta import utilities
 from grpc.framework.foundation import future
+
 from tests.unit.framework.common import test_constants
 
 

--- a/src/python/grpcio_tests/tests/unit/framework/common/__init__.py
+++ b/src/python/grpcio_tests/tests/unit/framework/common/__init__.py
@@ -13,9 +13,9 @@
 # limitations under the License.
 
 import contextlib
+import errno
 import os
 import socket
-import errno
 
 _DEFAULT_SOCK_OPTIONS = (socket.SO_REUSEADDR,
                          socket.SO_REUSEPORT) if os.name != 'nt' else (

--- a/src/python/grpcio_tests/tests/unit/test_common.py
+++ b/src/python/grpcio_tests/tests/unit/test_common.py
@@ -14,9 +14,9 @@
 """Common code used throughout tests of gRPC."""
 
 import collections
+from concurrent import futures
 import threading
 
-from concurrent import futures
 import grpc
 import six
 

--- a/src/python/grpcio_tests/tests/unit/thread_pool.py
+++ b/src/python/grpcio_tests/tests/unit/thread_pool.py
@@ -12,8 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import threading
 from concurrent import futures
+import threading
 
 
 class RecordingThreadPool(futures.ThreadPoolExecutor):

--- a/src/python/grpcio_tests/tests_aio/benchmark/benchmark_client.py
+++ b/src/python/grpcio_tests/tests_aio/benchmark/benchmark_client.py
@@ -15,15 +15,16 @@
 
 import abc
 import asyncio
-import time
 import logging
 import random
+import time
 
 import grpc
 from grpc.experimental import aio
 
-from src.proto.grpc.testing import (benchmark_service_pb2_grpc, control_pb2,
-                                    messages_pb2)
+from src.proto.grpc.testing import benchmark_service_pb2_grpc
+from src.proto.grpc.testing import control_pb2
+from src.proto.grpc.testing import messages_pb2
 from tests.qps import histogram
 from tests.unit import resources
 

--- a/src/python/grpcio_tests/tests_aio/benchmark/benchmark_servicer.py
+++ b/src/python/grpcio_tests/tests_aio/benchmark/benchmark_servicer.py
@@ -19,7 +19,8 @@ import unittest
 
 from grpc.experimental import aio
 
-from src.proto.grpc.testing import benchmark_service_pb2_grpc, messages_pb2
+from src.proto.grpc.testing import benchmark_service_pb2_grpc
+from src.proto.grpc.testing import messages_pb2
 
 
 class BenchmarkServicer(benchmark_service_pb2_grpc.BenchmarkServiceServicer):

--- a/src/python/grpcio_tests/tests_aio/benchmark/worker_servicer.py
+++ b/src/python/grpcio_tests/tests_aio/benchmark/worker_servicer.py
@@ -24,12 +24,15 @@ from typing import Tuple
 import grpc
 from grpc.experimental import aio
 
-from src.proto.grpc.testing import (benchmark_service_pb2_grpc, control_pb2,
-                                    stats_pb2, worker_service_pb2_grpc)
+from src.proto.grpc.testing import benchmark_service_pb2_grpc
+from src.proto.grpc.testing import control_pb2
+from src.proto.grpc.testing import stats_pb2
+from src.proto.grpc.testing import worker_service_pb2_grpc
 from tests.qps import histogram
 from tests.unit import resources
 from tests.unit.framework.common import get_socket
-from tests_aio.benchmark import benchmark_client, benchmark_servicer
+from tests_aio.benchmark import benchmark_client
+from tests_aio.benchmark import benchmark_servicer
 
 _NUM_CORES = multiprocessing.cpu_count()
 _WORKER_ENTRY_FILE = os.path.join(

--- a/src/python/grpcio_tests/tests_aio/channelz/channelz_servicer_test.py
+++ b/src/python/grpcio_tests/tests_aio/channelz/channelz_servicer_test.py
@@ -13,13 +13,12 @@
 # limitations under the License.
 """Tests of grpc_channelz.v1.channelz."""
 
-import unittest
-import logging
 import asyncio
+import logging
+import unittest
 
 import grpc
 from grpc.experimental import aio
-
 from grpc_channelz.v1 import channelz
 from grpc_channelz.v1 import channelz_pb2
 from grpc_channelz.v1 import channelz_pb2_grpc

--- a/src/python/grpcio_tests/tests_aio/health_check/health_servicer_test.py
+++ b/src/python/grpcio_tests/tests_aio/health_check/health_servicer_test.py
@@ -15,19 +15,17 @@
 
 import asyncio
 import logging
-import time
 import random
+import time
 import unittest
 
 import grpc
-
+from grpc.experimental import aio
 from grpc_health.v1 import health
 from grpc_health.v1 import health_pb2
 from grpc_health.v1 import health_pb2_grpc
-from grpc.experimental import aio
 
 from tests.unit.framework.common import test_constants
-
 from tests_aio.unit._test_base import AioTestBase
 
 _SERVING_SERVICE = 'grpc.test.TestServiceServing'

--- a/src/python/grpcio_tests/tests_aio/interop/methods.py
+++ b/src/python/grpcio_tests/tests_aio/interop/methods.py
@@ -25,14 +25,16 @@ import threading
 import time
 from typing import Any, Optional, Union
 
-import grpc
 from google import auth as google_auth
 from google.auth import environment_vars as google_auth_environment_vars
 from google.auth.transport import grpc as google_auth_transport_grpc
 from google.auth.transport import requests as google_auth_transport_requests
+import grpc
 from grpc.experimental import aio
 
-from src.proto.grpc.testing import empty_pb2, messages_pb2, test_pb2_grpc
+from src.proto.grpc.testing import empty_pb2
+from src.proto.grpc.testing import messages_pb2
+from src.proto.grpc.testing import test_pb2_grpc
 
 _INITIAL_METADATA_KEY = "x-grpc-test-echo-initial"
 _TRAILING_METADATA_KEY = "x-grpc-test-echo-trailing-bin"

--- a/src/python/grpcio_tests/tests_aio/interop/server.py
+++ b/src/python/grpcio_tests/tests_aio/interop/server.py
@@ -13,8 +13,8 @@
 # limitations under the License.
 """The gRPC interoperability test server using AsyncIO stack."""
 
-import asyncio
 import argparse
+import asyncio
 import logging
 
 import grpc

--- a/src/python/grpcio_tests/tests_aio/reflection/reflection_servicer_test.py
+++ b/src/python/grpcio_tests/tests_aio/reflection/reflection_servicer_test.py
@@ -16,12 +16,13 @@
 import logging
 import unittest
 
-import grpc
 from google.protobuf import descriptor_pb2
+import grpc
 from grpc.experimental import aio
+from grpc_reflection.v1alpha import reflection
+from grpc_reflection.v1alpha import reflection_pb2
+from grpc_reflection.v1alpha import reflection_pb2_grpc
 
-from grpc_reflection.v1alpha import (reflection, reflection_pb2,
-                                     reflection_pb2_grpc)
 from src.proto.grpc.testing import empty_pb2
 from src.proto.grpc.testing.proto2 import empty2_extensions_pb2
 from tests_aio.unit._test_base import AioTestBase

--- a/src/python/grpcio_tests/tests_aio/status/grpc_status_test.py
+++ b/src/python/grpcio_tests/tests_aio/status/grpc_status_test.py
@@ -17,12 +17,14 @@ import logging
 import traceback
 import unittest
 
-import grpc
 from google.protobuf import any_pb2
-from google.rpc import code_pb2, error_details_pb2, status_pb2
+from google.rpc import code_pb2
+from google.rpc import error_details_pb2
+from google.rpc import status_pb2
+import grpc
 from grpc.experimental import aio
-
 from grpc_status import rpc_status
+
 from tests_aio.unit._test_base import AioTestBase
 
 _STATUS_OK = '/test/StatusOK'

--- a/src/python/grpcio_tests/tests_aio/unit/_common.py
+++ b/src/python/grpcio_tests/tests_aio/unit/_common.py
@@ -13,11 +13,14 @@
 # limitations under the License.
 
 import asyncio
-import grpc
 from typing import AsyncIterable
-from grpc.experimental import aio
-from grpc.aio._typing import MetadatumType, MetadataKey, MetadataValue
+
+import grpc
 from grpc.aio._metadata import Metadata
+from grpc.aio._typing import MetadataKey
+from grpc.aio._typing import MetadataValue
+from grpc.aio._typing import MetadatumType
+from grpc.experimental import aio
 
 from tests.unit.framework.common import test_constants
 

--- a/src/python/grpcio_tests/tests_aio/unit/_test_base.py
+++ b/src/python/grpcio_tests/tests_aio/unit/_test_base.py
@@ -12,11 +12,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import logging
-import functools
 import asyncio
+import functools
+import logging
 from typing import Callable
 import unittest
+
 from grpc.experimental import aio
 
 __all__ = 'AioTestBase'

--- a/src/python/grpcio_tests/tests_aio/unit/_test_server.py
+++ b/src/python/grpcio_tests/tests_aio/unit/_test_server.py
@@ -17,9 +17,11 @@ import datetime
 
 import grpc
 from grpc.experimental import aio
-from tests.unit import resources
 
-from src.proto.grpc.testing import empty_pb2, messages_pb2, test_pb2_grpc
+from src.proto.grpc.testing import empty_pb2
+from src.proto.grpc.testing import messages_pb2
+from src.proto.grpc.testing import test_pb2_grpc
+from tests.unit import resources
 from tests_aio.unit import _constants
 
 _INITIAL_METADATA_KEY = "x-grpc-test-echo-initial"

--- a/src/python/grpcio_tests/tests_aio/unit/abort_test.py
+++ b/src/python/grpcio_tests/tests_aio/unit/abort_test.py
@@ -13,15 +13,16 @@
 # limitations under the License.
 
 import asyncio
-import logging
-import unittest
-import time
 import gc
+import logging
+import time
+import unittest
 
 import grpc
 from grpc.experimental import aio
-from tests_aio.unit._test_base import AioTestBase
+
 from tests.unit.framework.common import test_constants
+from tests_aio.unit._test_base import AioTestBase
 
 _UNARY_UNARY_ABORT = '/test/UnaryUnaryAbort'
 _SUPPRESS_ABORT = '/test/SuppressAbort'

--- a/src/python/grpcio_tests/tests_aio/unit/aio_rpc_error_test.py
+++ b/src/python/grpcio_tests/tests_aio/unit/aio_rpc_error_test.py
@@ -17,9 +17,9 @@ import logging
 import unittest
 
 import grpc
-
-from grpc.experimental import aio
 from grpc.aio._call import AioRpcError
+from grpc.experimental import aio
+
 from tests_aio.unit._test_base import AioTestBase
 
 _TEST_INITIAL_METADATA = aio.Metadata(

--- a/src/python/grpcio_tests/tests_aio/unit/auth_context_test.py
+++ b/src/python/grpcio_tests/tests_aio/unit/auth_context_test.py
@@ -13,9 +13,9 @@
 # limitations under the License.
 """Porting auth context tests from sync stack."""
 
+import logging
 import pickle
 import unittest
-import logging
 
 import grpc
 from grpc.experimental import aio

--- a/src/python/grpcio_tests/tests_aio/unit/call_test.py
+++ b/src/python/grpcio_tests/tests_aio/unit/call_test.py
@@ -14,17 +14,18 @@
 """Tests behavior of the Call classes."""
 
 import asyncio
+import datetime
 import logging
 import unittest
-import datetime
 
 import grpc
 from grpc.experimental import aio
 
-from src.proto.grpc.testing import messages_pb2, test_pb2_grpc
+from src.proto.grpc.testing import messages_pb2
+from src.proto.grpc.testing import test_pb2_grpc
+from tests_aio.unit._constants import UNREACHABLE_TARGET
 from tests_aio.unit._test_base import AioTestBase
 from tests_aio.unit._test_server import start_test_server
-from tests_aio.unit._constants import UNREACHABLE_TARGET
 
 _SHORT_TIMEOUT_S = datetime.timedelta(seconds=1).total_seconds()
 

--- a/src/python/grpcio_tests/tests_aio/unit/channel_argument_test.py
+++ b/src/python/grpcio_tests/tests_aio/unit/channel_argument_test.py
@@ -14,16 +14,17 @@
 """Tests behavior around the Core channel arguments."""
 
 import asyncio
+import errno
 import logging
 import platform
 import random
-import errno
 import unittest
 
 import grpc
 from grpc.experimental import aio
 
-from src.proto.grpc.testing import messages_pb2, test_pb2_grpc
+from src.proto.grpc.testing import messages_pb2
+from src.proto.grpc.testing import test_pb2_grpc
 from tests.unit.framework import common
 from tests_aio.unit._test_base import AioTestBase
 from tests_aio.unit._test_server import start_test_server

--- a/src/python/grpcio_tests/tests_aio/unit/channel_ready_test.py
+++ b/src/python/grpcio_tests/tests_aio/unit/channel_ready_test.py
@@ -23,7 +23,8 @@ import unittest
 import grpc
 from grpc.experimental import aio
 
-from tests.unit.framework.common import get_socket, test_constants
+from tests.unit.framework.common import get_socket
+from tests.unit.framework.common import test_constants
 from tests_aio.unit import _common
 from tests_aio.unit._test_base import AioTestBase
 from tests_aio.unit._test_server import start_test_server

--- a/src/python/grpcio_tests/tests_aio/unit/channel_test.py
+++ b/src/python/grpcio_tests/tests_aio/unit/channel_test.py
@@ -20,10 +20,11 @@ import unittest
 import grpc
 from grpc.experimental import aio
 
-from src.proto.grpc.testing import messages_pb2, test_pb2_grpc
+from src.proto.grpc.testing import messages_pb2
+from src.proto.grpc.testing import test_pb2_grpc
 from tests.unit.framework.common import test_constants
-from tests_aio.unit._constants import (UNARY_CALL_WITH_SLEEP_VALUE,
-                                       UNREACHABLE_TARGET)
+from tests_aio.unit._constants import UNARY_CALL_WITH_SLEEP_VALUE
+from tests_aio.unit._constants import UNREACHABLE_TARGET
 from tests_aio.unit._test_base import AioTestBase
 from tests_aio.unit._test_server import start_test_server
 

--- a/src/python/grpcio_tests/tests_aio/unit/client_stream_stream_interceptor_test.py
+++ b/src/python/grpcio_tests/tests_aio/unit/client_stream_stream_interceptor_test.py
@@ -15,12 +15,14 @@ import logging
 import unittest
 
 import grpc
-
 from grpc.experimental import aio
-from tests_aio.unit._common import CountingResponseIterator, CountingRequestIterator
-from tests_aio.unit._test_server import start_test_server
+
+from src.proto.grpc.testing import messages_pb2
+from src.proto.grpc.testing import test_pb2_grpc
+from tests_aio.unit._common import CountingRequestIterator
+from tests_aio.unit._common import CountingResponseIterator
 from tests_aio.unit._test_base import AioTestBase
-from src.proto.grpc.testing import messages_pb2, test_pb2_grpc
+from tests_aio.unit._test_server import start_test_server
 
 _NUM_STREAM_RESPONSES = 5
 _NUM_STREAM_REQUESTS = 5

--- a/src/python/grpcio_tests/tests_aio/unit/client_stream_unary_interceptor_test.py
+++ b/src/python/grpcio_tests/tests_aio/unit/client_stream_unary_interceptor_test.py
@@ -12,20 +12,21 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 import asyncio
+import datetime
 import logging
 import unittest
-import datetime
 
 import grpc
-
 from grpc.experimental import aio
-from tests_aio.unit._constants import UNREACHABLE_TARGET
-from tests_aio.unit._common import inject_callbacks
-from tests_aio.unit._common import CountingRequestIterator
-from tests_aio.unit._test_server import start_test_server
-from tests_aio.unit._test_base import AioTestBase
+
+from src.proto.grpc.testing import messages_pb2
+from src.proto.grpc.testing import test_pb2_grpc
 from tests.unit.framework.common import test_constants
-from src.proto.grpc.testing import messages_pb2, test_pb2_grpc
+from tests_aio.unit._common import CountingRequestIterator
+from tests_aio.unit._common import inject_callbacks
+from tests_aio.unit._constants import UNREACHABLE_TARGET
+from tests_aio.unit._test_base import AioTestBase
+from tests_aio.unit._test_server import start_test_server
 
 _SHORT_TIMEOUT_S = 1.0
 

--- a/src/python/grpcio_tests/tests_aio/unit/client_unary_stream_interceptor_test.py
+++ b/src/python/grpcio_tests/tests_aio/unit/client_unary_stream_interceptor_test.py
@@ -12,20 +12,21 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 import asyncio
+import datetime
 import logging
 import unittest
-import datetime
 
 import grpc
-
 from grpc.experimental import aio
-from tests_aio.unit._constants import UNREACHABLE_TARGET
-from tests_aio.unit._common import inject_callbacks
-from tests_aio.unit._common import CountingResponseIterator
-from tests_aio.unit._test_server import start_test_server
-from tests_aio.unit._test_base import AioTestBase
+
+from src.proto.grpc.testing import messages_pb2
+from src.proto.grpc.testing import test_pb2_grpc
 from tests.unit.framework.common import test_constants
-from src.proto.grpc.testing import messages_pb2, test_pb2_grpc
+from tests_aio.unit._common import CountingResponseIterator
+from tests_aio.unit._common import inject_callbacks
+from tests_aio.unit._constants import UNREACHABLE_TARGET
+from tests_aio.unit._test_base import AioTestBase
+from tests_aio.unit._test_server import start_test_server
 
 _SHORT_TIMEOUT_S = 1.0
 

--- a/src/python/grpcio_tests/tests_aio/unit/client_unary_unary_interceptor_test.py
+++ b/src/python/grpcio_tests/tests_aio/unit/client_unary_unary_interceptor_test.py
@@ -16,13 +16,16 @@ import logging
 import unittest
 
 import grpc
-
 from grpc.experimental import aio
-from tests_aio.unit._test_server import start_test_server, _INITIAL_METADATA_KEY, _TRAILING_METADATA_KEY
-from tests_aio.unit import _constants
+
+from src.proto.grpc.testing import messages_pb2
+from src.proto.grpc.testing import test_pb2_grpc
 from tests_aio.unit import _common
+from tests_aio.unit import _constants
 from tests_aio.unit._test_base import AioTestBase
-from src.proto.grpc.testing import messages_pb2, test_pb2_grpc
+from tests_aio.unit._test_server import _INITIAL_METADATA_KEY
+from tests_aio.unit._test_server import _TRAILING_METADATA_KEY
+from tests_aio.unit._test_server import start_test_server
 
 _LOCAL_CANCEL_DETAILS_EXPECTATION = 'Locally cancelled by application!'
 _INITIAL_METADATA_TO_INJECT = aio.Metadata(

--- a/src/python/grpcio_tests/tests_aio/unit/close_channel_test.py
+++ b/src/python/grpcio_tests/tests_aio/unit/close_channel_test.py
@@ -18,10 +18,11 @@ import logging
 import unittest
 
 import grpc
-from grpc.experimental import aio
 from grpc.aio import _base_call
+from grpc.experimental import aio
 
-from src.proto.grpc.testing import messages_pb2, test_pb2_grpc
+from src.proto.grpc.testing import messages_pb2
+from src.proto.grpc.testing import test_pb2_grpc
 from tests_aio.unit._test_base import AioTestBase
 from tests_aio.unit._test_server import start_test_server
 

--- a/src/python/grpcio_tests/tests_aio/unit/compatibility_test.py
+++ b/src/python/grpcio_tests/tests_aio/unit/compatibility_test.py
@@ -14,22 +14,24 @@
 """Testing the compatibility between AsyncIO stack and the old stack."""
 
 import asyncio
+from concurrent.futures import ThreadPoolExecutor
 import logging
 import os
 import random
 import threading
-import unittest
-from concurrent.futures import ThreadPoolExecutor
 from typing import Callable, Iterable, Sequence, Tuple
+import unittest
 
 import grpc
 from grpc.experimental import aio
 
-from src.proto.grpc.testing import messages_pb2, test_pb2_grpc
+from src.proto.grpc.testing import messages_pb2
+from src.proto.grpc.testing import test_pb2_grpc
 from tests.unit.framework.common import test_constants
 from tests_aio.unit import _common
 from tests_aio.unit._test_base import AioTestBase
-from tests_aio.unit._test_server import TestServiceServicer, start_test_server
+from tests_aio.unit._test_server import TestServiceServicer
+from tests_aio.unit._test_server import start_test_server
 
 _NUM_STREAM_RESPONSES = 5
 _REQUEST_PAYLOAD_SIZE = 7

--- a/src/python/grpcio_tests/tests_aio/unit/compression_test.py
+++ b/src/python/grpcio_tests/tests_aio/unit/compression_test.py
@@ -22,8 +22,8 @@ import unittest
 import grpc
 from grpc.experimental import aio
 
-from tests_aio.unit._test_base import AioTestBase
 from tests_aio.unit import _common
+from tests_aio.unit._test_base import AioTestBase
 
 _GZIP_CHANNEL_ARGUMENT = ('grpc.default_compression_algorithm', 2)
 _GZIP_DISABLED_CHANNEL_ARGUMENT = ('grpc.compression_enabled_algorithms_bitset',

--- a/src/python/grpcio_tests/tests_aio/unit/context_peer_test.py
+++ b/src/python/grpcio_tests/tests_aio/unit/context_peer_test.py
@@ -16,17 +16,19 @@
 import asyncio
 import logging
 import os
-import unittest
 from typing import Callable, Iterable, Sequence, Tuple
+import unittest
 
 import grpc
 from grpc.experimental import aio
 
-from src.proto.grpc.testing import messages_pb2, test_pb2_grpc
+from src.proto.grpc.testing import messages_pb2
+from src.proto.grpc.testing import test_pb2_grpc
 from tests.unit.framework.common import test_constants
 from tests_aio.unit import _common
 from tests_aio.unit._test_base import AioTestBase
-from tests_aio.unit._test_server import TestServiceServicer, start_test_server
+from tests_aio.unit._test_server import TestServiceServicer
+from tests_aio.unit._test_server import start_test_server
 
 _REQUEST = b'\x03\x07'
 _TEST_METHOD = '/test/UnaryUnary'

--- a/src/python/grpcio_tests/tests_aio/unit/done_callback_test.py
+++ b/src/python/grpcio_tests/tests_aio/unit/done_callback_test.py
@@ -14,17 +14,19 @@
 """Testing the done callbacks mechanism."""
 
 import asyncio
-import logging
-import unittest
-import time
 import gc
+import logging
+import time
+import unittest
 
 import grpc
 from grpc.experimental import aio
+
+from src.proto.grpc.testing import messages_pb2
+from src.proto.grpc.testing import test_pb2_grpc
+from tests.unit.framework.common import test_constants
 from tests_aio.unit._common import inject_callbacks
 from tests_aio.unit._test_base import AioTestBase
-from tests.unit.framework.common import test_constants
-from src.proto.grpc.testing import messages_pb2, test_pb2_grpc
 from tests_aio.unit._test_server import start_test_server
 
 _NUM_STREAM_RESPONSES = 5

--- a/src/python/grpcio_tests/tests_aio/unit/metadata_test.py
+++ b/src/python/grpcio_tests/tests_aio/unit/metadata_test.py
@@ -22,8 +22,8 @@ import unittest
 import grpc
 from grpc.experimental import aio
 
-from tests_aio.unit._test_base import AioTestBase
 from tests_aio.unit import _common
+from tests_aio.unit._test_base import AioTestBase
 
 _TEST_CLIENT_TO_SERVER = '/test/TestClientToServer'
 _TEST_SERVER_TO_CLIENT = '/test/TestServerToClient'

--- a/src/python/grpcio_tests/tests_aio/unit/outside_init_test.py
+++ b/src/python/grpcio_tests/tests_aio/unit/outside_init_test.py
@@ -16,11 +16,13 @@
 import asyncio
 import logging
 import unittest
-from grpc.experimental import aio
-import grpc
 
+import grpc
+from grpc.experimental import aio
+
+from src.proto.grpc.testing import messages_pb2
+from src.proto.grpc.testing import test_pb2_grpc
 from tests_aio.unit._test_server import start_test_server
-from src.proto.grpc.testing import messages_pb2, test_pb2_grpc
 
 _NUM_OF_LOOPS = 50
 

--- a/src/python/grpcio_tests/tests_aio/unit/secure_call_test.py
+++ b/src/python/grpcio_tests/tests_aio/unit/secure_call_test.py
@@ -13,15 +13,17 @@
 # limitations under the License.
 """Tests the behaviour of the Call classes under a secure channel."""
 
-import unittest
 import logging
+import unittest
 
 import grpc
 from grpc.experimental import aio
-from src.proto.grpc.testing import messages_pb2, test_pb2_grpc
+
+from src.proto.grpc.testing import messages_pb2
+from src.proto.grpc.testing import test_pb2_grpc
+from tests.unit import resources
 from tests_aio.unit._test_base import AioTestBase
 from tests_aio.unit._test_server import start_test_server
-from tests.unit import resources
 
 _SERVER_HOST_OVERRIDE = 'foo.test.google.fr'
 _NUM_STREAM_RESPONSES = 5

--- a/src/python/grpcio_tests/tests_aio/unit/server_interceptor_test.py
+++ b/src/python/grpcio_tests/tests_aio/unit/server_interceptor_test.py
@@ -16,13 +16,15 @@
 import asyncio
 import functools
 import logging
-import unittest
 from typing import Any, Awaitable, Callable, Tuple
+import unittest
 
 import grpc
-from grpc.experimental import aio, wrap_server_method_handler
+from grpc.experimental import aio
+from grpc.experimental import wrap_server_method_handler
 
-from src.proto.grpc.testing import messages_pb2, test_pb2_grpc
+from src.proto.grpc.testing import messages_pb2
+from src.proto.grpc.testing import test_pb2_grpc
 from tests_aio.unit._test_base import AioTestBase
 from tests_aio.unit._test_server import start_test_server
 

--- a/src/python/grpcio_tests/tests_aio/unit/server_time_remaining_test.py
+++ b/src/python/grpcio_tests/tests_aio/unit/server_time_remaining_test.py
@@ -14,14 +14,15 @@
 """Test the time_remaining() method of async ServicerContext."""
 
 import asyncio
+import datetime
 import logging
 import unittest
-import datetime
 
 import grpc
 from grpc import aio
 
-from tests_aio.unit._common import ADHOC_METHOD, AdhocGenericHandler
+from tests_aio.unit._common import ADHOC_METHOD
+from tests_aio.unit._common import AdhocGenericHandler
 from tests_aio.unit._test_base import AioTestBase
 
 _REQUEST = b'\x09\x05'

--- a/src/python/grpcio_tests/tests_aio/unit/timeout_test.py
+++ b/src/python/grpcio_tests/tests_aio/unit/timeout_test.py
@@ -14,17 +14,17 @@
 """Tests behavior of the timeout mechanism on client side."""
 
 import asyncio
+import datetime
 import logging
 import platform
 import random
 import unittest
-import datetime
 
 import grpc
 from grpc.experimental import aio
 
-from tests_aio.unit._test_base import AioTestBase
 from tests_aio.unit import _common
+from tests_aio.unit._test_base import AioTestBase
 
 _SLEEP_TIME_UNIT_S = datetime.timedelta(seconds=1).total_seconds()
 

--- a/src/python/grpcio_tests/tests_aio/unit/wait_for_connection_test.py
+++ b/src/python/grpcio_tests/tests_aio/unit/wait_for_connection_test.py
@@ -14,19 +14,20 @@
 """Tests behavior of the wait for connection API on client side."""
 
 import asyncio
-import logging
-import unittest
 import datetime
+import logging
 from typing import Callable, Tuple
+import unittest
 
 import grpc
 from grpc.experimental import aio
 
+from src.proto.grpc.testing import messages_pb2
+from src.proto.grpc.testing import test_pb2_grpc
+from tests_aio.unit import _common
+from tests_aio.unit._constants import UNREACHABLE_TARGET
 from tests_aio.unit._test_base import AioTestBase
 from tests_aio.unit._test_server import start_test_server
-from tests_aio.unit import _common
-from src.proto.grpc.testing import messages_pb2, test_pb2_grpc
-from tests_aio.unit._constants import UNREACHABLE_TARGET
 
 _REQUEST = b'\x01\x02\x03'
 _TEST_METHOD = '/test/Test'

--- a/src/python/grpcio_tests/tests_aio/unit/wait_for_ready_test.py
+++ b/src/python/grpcio_tests/tests_aio/unit/wait_for_ready_test.py
@@ -14,20 +14,22 @@
 """Testing the done callbacks mechanism."""
 
 import asyncio
-import logging
-import unittest
-import time
 import gc
+import logging
 import platform
+import time
+import unittest
 
 import grpc
 from grpc.experimental import aio
-from tests_aio.unit._test_base import AioTestBase
-from tests.unit.framework.common import test_constants
+
+from src.proto.grpc.testing import messages_pb2
+from src.proto.grpc.testing import test_pb2_grpc
 from tests.unit.framework.common import get_socket
-from src.proto.grpc.testing import messages_pb2, test_pb2_grpc
-from tests_aio.unit._test_server import start_test_server
+from tests.unit.framework.common import test_constants
 from tests_aio.unit import _common
+from tests_aio.unit._test_base import AioTestBase
+from tests_aio.unit._test_server import start_test_server
 
 _NUM_STREAM_RESPONSES = 5
 _REQUEST_PAYLOAD_SIZE = 7

--- a/src/python/grpcio_tests/tests_gevent/unit/_test_server.py
+++ b/src/python/grpcio_tests/tests_gevent/unit/_test_server.py
@@ -13,10 +13,13 @@
 # limitations under the License.
 
 from concurrent import futures
-from src.proto.grpc.testing import messages_pb2, test_pb2_grpc
-import grpc
-import gevent
 from typing import Any, Tuple
+
+import gevent
+import grpc
+
+from src.proto.grpc.testing import messages_pb2
+from src.proto.grpc.testing import test_pb2_grpc
 
 LONG_UNARY_CALL_WITH_SLEEP_VALUE = 1
 

--- a/src/python/grpcio_tests/tests_gevent/unit/close_channel_test.py
+++ b/src/python/grpcio_tests/tests_gevent/unit/close_channel_test.py
@@ -12,12 +12,15 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import unittest
-from src.proto.grpc.testing import messages_pb2, test_pb2_grpc
-import grpc
-import gevent
 import sys
+import unittest
+
+import gevent
 from gevent.pool import Group
+import grpc
+
+from src.proto.grpc.testing import messages_pb2
+from src.proto.grpc.testing import test_pb2_grpc
 from tests_gevent.unit._test_server import start_test_server
 
 _UNARY_CALL_METHOD_WITH_SLEEP = '/grpc.testing.TestService/UnaryCallWithSleep'

--- a/src/python/grpcio_tests/tests_py3_only/interop/xds_interop_client.py
+++ b/src/python/grpcio_tests/tests_py3_only/interop/xds_interop_client.py
@@ -14,26 +14,23 @@
 
 import argparse
 import collections
+from concurrent import futures
 import datetime
 import logging
 import signal
+import sys
 import threading
 import time
-import sys
-
-from typing import DefaultDict, Dict, List, Mapping, Set, Sequence, Tuple
-import collections
-
-from concurrent import futures
+from typing import DefaultDict, Dict, List, Mapping, Sequence, Set, Tuple
 
 import grpc
-from grpc_channelz.v1 import channelz
 import grpc_admin
+from grpc_channelz.v1 import channelz
 
+from src.proto.grpc.testing import empty_pb2
+from src.proto.grpc.testing import messages_pb2
 from src.proto.grpc.testing import test_pb2
 from src.proto.grpc.testing import test_pb2_grpc
-from src.proto.grpc.testing import messages_pb2
-from src.proto.grpc.testing import empty_pb2
 
 logger = logging.getLogger()
 console_handler = logging.StreamHandler()

--- a/src/python/grpcio_tests/tests_py3_only/interop/xds_interop_server.py
+++ b/src/python/grpcio_tests/tests_py3_only/interop/xds_interop_server.py
@@ -13,29 +13,28 @@
 # limitations under the License.
 
 import argparse
+import collections
+from concurrent import futures
 import logging
 import signal
-import threading
-import time
 import socket
 import sys
-
-from typing import DefaultDict, Dict, List, Mapping, Set, Sequence, Tuple
-import collections
-
-from concurrent import futures
+import threading
+import time
+from typing import DefaultDict, Dict, List, Mapping, Sequence, Set, Tuple
 
 import grpc
 from grpc_channelz.v1 import channelz
 from grpc_channelz.v1 import channelz_pb2
-from grpc_health.v1 import health_pb2, health_pb2_grpc
 from grpc_health.v1 import health as grpc_health
+from grpc_health.v1 import health_pb2
+from grpc_health.v1 import health_pb2_grpc
 from grpc_reflection.v1alpha import reflection
 
+from src.proto.grpc.testing import empty_pb2
+from src.proto.grpc.testing import messages_pb2
 from src.proto.grpc.testing import test_pb2
 from src.proto.grpc.testing import test_pb2_grpc
-from src.proto.grpc.testing import messages_pb2
-from src.proto.grpc.testing import empty_pb2
 
 # NOTE: This interop server is not fully compatible with all xDS interop tests.
 #  It currently only implements enough functionality to pass the xDS security

--- a/src/python/grpcio_tests/tests_py3_only/unit/_leak_test.py
+++ b/src/python/grpcio_tests/tests_py3_only/unit/_leak_test.py
@@ -18,12 +18,12 @@ explicitly invoked. The recommended way of using Channel object is using `with`
 clause, and let context manager automatically close the channel.
 """
 
+from concurrent.futures import ThreadPoolExecutor
 import logging
 import os
 import resource
 import sys
 import unittest
-from concurrent.futures import ThreadPoolExecutor
 
 import grpc
 

--- a/src/python/grpcio_tests/tests_py3_only/unit/_simple_stubs_test.py
+++ b/src/python/grpcio_tests/tests_py3_only/unit/_simple_stubs_test.py
@@ -29,17 +29,18 @@ import contextlib
 import datetime
 import inspect
 import logging
-import threading
-import unittest
 import sys
+import threading
 import time
 from typing import Callable, Optional
+import unittest
 
-from tests.unit import test_common
-from tests.unit.framework.common import get_socket
-from tests.unit import resources
 import grpc
 import grpc.experimental
+
+from tests.unit import resources
+from tests.unit import test_common
+from tests.unit.framework.common import get_socket
 
 _REQUEST = b"0000"
 

--- a/templates/test/cpp/naming/resolver_component_tests_defs.include
+++ b/templates/test/cpp/naming/resolver_component_tests_defs.include
@@ -16,14 +16,13 @@
 # This file is auto-generated
 
 import argparse
-import sys
-import subprocess
-import tempfile
 import os
-import time
-import signal
 import platform
-
+import signal
+import subprocess
+import sys
+import tempfile
+import time
 
 argp = argparse.ArgumentParser(description='Run c-ares resolver tests')
 argp.add_argument('--test_bin_path', default=None, type=str,

--- a/test/core/end2end/gen_build_yaml.py
+++ b/test/core/end2end/gen_build_yaml.py
@@ -15,6 +15,7 @@
 
 import os
 import sys
+
 import yaml
 
 _ROOT = os.path.abspath(os.path.join(os.path.dirname(sys.argv[0]), '../../..'))

--- a/test/core/http/test_server.py
+++ b/test/core/http/test_server.py
@@ -15,10 +15,11 @@
 """Server for httpcli_test"""
 
 import argparse
-import BaseHTTPServer
 import os
 import ssl
 import sys
+
+import BaseHTTPServer
 
 _PEM = os.path.abspath(
     os.path.join(os.path.dirname(sys.argv[0]), '../../..',

--- a/test/cpp/naming/gen_build_yaml.py
+++ b/test/cpp/naming/gen_build_yaml.py
@@ -14,10 +14,11 @@
 # limitations under the License.
 """Generates the appropriate build.json data for all the naming tests."""
 
-import yaml
 import collections
 import hashlib
 import json
+
+import yaml
 
 _LOCAL_DNS_SERVER_ADDRESS = '127.0.0.1:15353'
 

--- a/test/cpp/naming/resolver_component_tests_runner.py
+++ b/test/cpp/naming/resolver_component_tests_runner.py
@@ -16,14 +16,13 @@
 # This file is auto-generated
 
 import argparse
-import sys
-import subprocess
-import tempfile
 import os
-import time
-import signal
 import platform
-
+import signal
+import subprocess
+import sys
+import tempfile
+import time
 
 argp = argparse.ArgumentParser(description='Run c-ares resolver tests')
 argp.add_argument('--test_bin_path', default=None, type=str,

--- a/test/cpp/naming/utils/dns_resolver.py
+++ b/test/cpp/naming/utils/dns_resolver.py
@@ -17,9 +17,10 @@
 import argparse
 import threading
 import time
+
+import twisted.internet.reactor as reactor
 import twisted.internet.task as task
 import twisted.names.client as client
-import twisted.internet.reactor as reactor
 
 
 def main():

--- a/test/cpp/naming/utils/dns_server.py
+++ b/test/cpp/naming/utils/dns_server.py
@@ -15,26 +15,29 @@
 """Starts a local DNS server for use in tests"""
 
 import argparse
-import sys
-import yaml
-import signal
 import os
+import platform
+import signal
+import sys
 import threading
 import time
 
 import twisted
 import twisted.internet
-import twisted.internet.reactor
-import twisted.internet.threads
 import twisted.internet.defer
 import twisted.internet.protocol
+import twisted.internet.reactor
+import twisted.internet.threads
 import twisted.names
+from twisted.names import authority
+from twisted.names import client
+from twisted.names import common
+from twisted.names import dns
+from twisted.names import server
 import twisted.names.client
 import twisted.names.dns
 import twisted.names.server
-from twisted.names import client, server, common, authority, dns
-import argparse
-import platform
+import yaml
 
 _SERVER_HEALTH_CHECK_RECORD_NAME = 'health-check-local-dns-server-is-alive.resolver-tests.grpctestingexp'  # missing end '.' for twisted syntax
 _SERVER_HEALTH_CHECK_RECORD_DATA = '123.123.123.123'

--- a/test/cpp/naming/utils/run_dns_server_for_lb_interop_tests.py
+++ b/test/cpp/naming/utils/run_dns_server_for_lb_interop_tests.py
@@ -14,12 +14,13 @@
 # limitations under the License.
 
 import argparse
-import subprocess
 import os
-import tempfile
-import sys
-import time
 import signal
+import subprocess
+import sys
+import tempfile
+import time
+
 import yaml
 
 argp = argparse.ArgumentParser(

--- a/test/cpp/naming/utils/tcp_connect.py
+++ b/test/cpp/naming/utils/tcp_connect.py
@@ -16,9 +16,9 @@
 
 import argparse
 import socket
+import sys
 import threading
 import time
-import sys
 
 
 def main():

--- a/test/cpp/qps/gen_build_yaml.py
+++ b/test/cpp/qps/gen_build_yaml.py
@@ -15,11 +15,13 @@
 # limitations under the License.
 
 from __future__ import print_function
+
 import json
+import os
 import pipes
 import shutil
 import sys
-import os
+
 import yaml
 
 run_tests_root = os.path.abspath(

--- a/test/cpp/qps/json_run_localhost_scenario_gen.py
+++ b/test/cpp/qps/json_run_localhost_scenario_gen.py
@@ -14,8 +14,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import gen_build_yaml as gen
 import json
+
+import gen_build_yaml as gen
 
 COPYRIGHT = """
 # Copyright 2021 The gRPC Authors

--- a/test/cpp/qps/qps_json_driver_scenario_gen.py
+++ b/test/cpp/qps/qps_json_driver_scenario_gen.py
@@ -14,8 +14,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import gen_build_yaml as gen
 import json
+
+import gen_build_yaml as gen
 
 COPYRIGHT = """
 # Copyright 2021 The gRPC Authors

--- a/test/http2_test/http2_base_server.py
+++ b/test/http2_test/http2_base_server.py
@@ -13,11 +13,11 @@
 # limitations under the License.
 
 import logging
-import messages_pb2
 import struct
 
 import h2
 import h2.connection
+import messages_pb2
 import twisted
 import twisted.internet
 import twisted.internet.protocol

--- a/test/http2_test/http2_server_health_check.py
+++ b/test/http2_test/http2_server_health_check.py
@@ -13,8 +13,9 @@
 # limitations under the License.
 
 import argparse
-import hyper
 import sys
+
+import hyper
 
 # Utility to healthcheck the http2 server. Used when starting the server to
 # verify that the server is live before tests begin.

--- a/test/http2_test/http2_test_server.py
+++ b/test/http2_test/http2_test_server.py
@@ -16,19 +16,19 @@
 import argparse
 import logging
 import sys
-import twisted
-import twisted.internet
-import twisted.internet.endpoints
-import twisted.internet.reactor
 
 import http2_base_server
+import test_data_frame_padding
 import test_goaway
 import test_max_streams
 import test_ping
 import test_rst_after_data
 import test_rst_after_header
 import test_rst_during_data
-import test_data_frame_padding
+import twisted
+import twisted.internet
+import twisted.internet.endpoints
+import twisted.internet.reactor
 
 _TEST_CASE_MAPPING = {
     'rst_after_header': test_rst_after_header.TestcaseRstStreamAfterHeader,

--- a/test/http2_test/test_data_frame_padding.py
+++ b/test/http2_test/test_data_frame_padding.py
@@ -12,8 +12,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import http2_base_server
 import logging
+
+import http2_base_server
 import messages_pb2
 
 # Set the number of padding bytes per data frame to be very large

--- a/test/http2_test/test_max_streams.py
+++ b/test/http2_test/test_max_streams.py
@@ -12,10 +12,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import hyperframe.frame
 import logging
 
 import http2_base_server
+import hyperframe.frame
 
 
 class TestcaseSettingsMaxStreams(object):

--- a/tools/buildgen/_mako_renderer.py
+++ b/tools/buildgen/_mako_renderer.py
@@ -26,11 +26,11 @@ import shutil
 import sys
 from typing import List
 
-import yaml
 from mako import exceptions
 from mako.lookup import TemplateLookup
 from mako.runtime import Context
 from mako.template import Template
+import yaml
 
 PROJECT_ROOT = os.path.join(os.path.dirname(os.path.abspath(__file__)), "..",
                             "..")

--- a/tools/buildgen/_utils.py
+++ b/tools/buildgen/_utils.py
@@ -14,11 +14,11 @@
 # limitations under the License.
 """Utility functions for build file generation scripts."""
 
+import importlib.util
 import os
 import sys
 import types
-import importlib.util
-from typing import Any, Union, Mapping, List
+from typing import Any, List, Mapping, Union
 
 
 def import_python_module(path: str) -> types.ModuleType:

--- a/tools/buildgen/build_cleaner.py
+++ b/tools/buildgen/build_cleaner.py
@@ -18,6 +18,7 @@
 import collections
 import os
 import sys
+
 import yaml
 
 TEST = (os.environ.get('TEST', 'false') == 'true')

--- a/tools/buildgen/extract_metadata_from_bazel_xml.py
+++ b/tools/buildgen/extract_metadata_from_bazel_xml.py
@@ -30,15 +30,16 @@
 # format entirely or simplify it to a point where it becomes self-explanatory
 # and doesn't need any detailed documentation.
 
-import subprocess
-import yaml
-import xml.etree.ElementTree as ET
-import os
 import collections
-import sys
+import os
 import re
-from typing import List, Any, Dict, Optional, Iterable
+import subprocess
+import sys
+from typing import Any, Dict, Iterable, List, Optional
+import xml.etree.ElementTree as ET
+
 import build_cleaner
+import yaml
 
 BuildMetadata = Dict[str, Any]
 BuildDict = Dict[str, BuildMetadata]

--- a/tools/buildgen/generate_projects.py
+++ b/tools/buildgen/generate_projects.py
@@ -14,16 +14,16 @@
 
 import argparse
 import glob
-import yaml
-import pickle
+import multiprocessing
 import os
+import pickle
 import shutil
 import sys
 import tempfile
-import multiprocessing
-from typing import Union, Dict, List
+from typing import Dict, List, Union
 
 import _utils
+import yaml
 
 PROJECT_ROOT = os.path.join(os.path.dirname(os.path.abspath(__file__)), "..",
                             "..")

--- a/tools/buildgen/plugins/list_api.py
+++ b/tools/buildgen/plugins/list_api.py
@@ -19,6 +19,7 @@ import fnmatch
 import os
 import re
 import sys
+
 import yaml
 
 _RE_API = r'(?:GPRAPI|GRPCAPI|CENSUSAPI)([^;]*);'

--- a/tools/codegen/core/gen_header_frame.py
+++ b/tools/codegen/core/gen_header_frame.py
@@ -19,9 +19,9 @@
    Write a set of strings containing a hpack encoded http2 frame that
    represents said headers."""
 
+import argparse
 import json
 import sys
-import argparse
 
 
 def append_never_indexed(payload_line, n, count, key, value):

--- a/tools/codegen/core/gen_settings_ids.py
+++ b/tools/codegen/core/gen_settings_ids.py
@@ -15,8 +15,9 @@
 # limitations under the License.
 
 import collections
-import perfection
 import sys
+
+import perfection
 
 _MAX_HEADER_LIST_SIZE = 16 * 1024 * 1024
 

--- a/tools/codegen/core/gen_static_metadata.py
+++ b/tools/codegen/core/gen_static_metadata.py
@@ -14,13 +14,14 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import collections
 import hashlib
 import itertools
-import collections
 import os
-import sys
-import subprocess
 import re
+import subprocess
+import sys
+
 import perfection
 
 # Configuration: a list of either strings or 2-tuples of strings.

--- a/tools/codegen/core/gen_stats_data.py
+++ b/tools/codegen/core/gen_stats_data.py
@@ -16,10 +16,11 @@
 
 import collections
 import ctypes
+import json
 import math
 import sys
+
 import yaml
-import json
 
 with open('src/core/lib/debug/stats_data.yaml') as f:
     attrs = yaml.load(f.read())

--- a/tools/debug/core/chttp2_ref_leak.py
+++ b/tools/debug/core/chttp2_ref_leak.py
@@ -17,8 +17,8 @@
 # to stdout
 
 import collections
-import sys
 import re
+import sys
 
 
 def new_obj():

--- a/tools/debug/core/error_ref_leak.py
+++ b/tools/debug/core/error_ref_leak.py
@@ -19,8 +19,8 @@
 
 # usage: python error_ref_leak < logfile.txt
 
-import sys
 import re
+import sys
 
 data = sys.stdin.readlines()
 

--- a/tools/distrib/check_copyright.py
+++ b/tools/distrib/check_copyright.py
@@ -18,8 +18,8 @@ import argparse
 import datetime
 import os
 import re
-import sys
 import subprocess
+import sys
 
 # find our home
 ROOT = os.path.abspath(os.path.join(os.path.dirname(sys.argv[0]), '../..'))

--- a/tools/distrib/check_include_guards.py
+++ b/tools/distrib/check_include_guards.py
@@ -18,8 +18,8 @@ import argparse
 import os
 import os.path
 import re
-import sys
 import subprocess
+import sys
 
 
 def build_valid_guard(fpath):

--- a/tools/distrib/gen_compilation_database.py
+++ b/tools/distrib/gen_compilation_database.py
@@ -22,10 +22,10 @@ import glob
 import json
 import logging
 import os
+from pathlib import Path
 import re
 import shlex
 import subprocess
-from pathlib import Path
 
 RE_INCLUDE_SYSTEM = re.compile("\s*-I\s+/usr/[^ ]+")
 

--- a/tools/distrib/isort_code.sh
+++ b/tools/distrib/isort_code.sh
@@ -1,0 +1,57 @@
+#!/bin/bash
+# Copyright 2021 The gRPC Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -ex
+
+ACTION=${1:---overwrite-in-place}
+[[ $ACTION == '--overwrite-in-place' ]] || [[ $ACTION == '--diff' ]]
+
+if [[ $ACTION == '--diff' ]]; then
+    ACTION="--diff --check"
+fi
+
+# Change to root
+cd "$(dirname "${0}")/../.."
+
+DIRS=(
+    'examples/python'
+    'src/python'
+    'test'
+    'tools'
+    'setup.py'
+)
+
+VIRTUALENV=isort_virtual_environment
+
+python3 -m virtualenv $VIRTUALENV
+PYTHON=${VIRTUALENV}/bin/python
+"$PYTHON" -m pip install isort==5.9.2
+
+$PYTHON -m isort $ACTION \
+  --force-sort-within-sections \
+  --force-single-line-imports --single-line-exclusions=typing \
+  --src "examples/python/data_transmission" \
+  --src "examples/python/async_streaming" \
+  --src "tools/run_tests/xds_k8s_test_driver" \
+  --src "src/python/grpcio_tests" \
+  --src "tools/run_tests" \
+  --project "examples" \
+  --project "src" \
+  --thirdparty "grpc" \
+  --skip-glob "third_party/*" \
+  --skip-glob "*/env/*" \
+  --skip-glob "*pb2*.py" \
+  --dont-follow-links \
+  "${DIRS[@]}"

--- a/tools/distrib/python/docgen.py
+++ b/tools/distrib/python/docgen.py
@@ -22,6 +22,7 @@ import shutil
 import subprocess
 import sys
 import tempfile
+
 import grpc_version
 
 parser = argparse.ArgumentParser()

--- a/tools/distrib/python/grpcio_tools/grpc_tools/_protoc_compiler.pyx
+++ b/tools/distrib/python/grpcio_tools/grpc_tools/_protoc_compiler.pyx
@@ -12,14 +12,14 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from libc cimport stdlib
-from libcpp.vector cimport vector
-from libcpp.utility cimport pair
-from libcpp.string cimport string
-
 from cython.operator cimport dereference
+from libc cimport stdlib
+from libcpp.string cimport string
+from libcpp.utility cimport pair
+from libcpp.vector cimport vector
 
 import warnings
+
 
 cdef extern from "grpc_tools/main.h" namespace "grpc_tools":
   cppclass cProtocError "::grpc_tools::ProtocError":

--- a/tools/distrib/python/grpcio_tools/grpc_tools/command.py
+++ b/tools/distrib/python/grpcio_tools/grpc_tools/command.py
@@ -13,12 +13,11 @@
 # limitations under the License.
 
 import os
-import pkg_resources
 import sys
 
-import setuptools
-
 from grpc_tools import protoc
+import pkg_resources
+import setuptools
 
 
 def build_package_protos(package_root, strict_mode=False):

--- a/tools/distrib/python/grpcio_tools/grpc_tools/protoc.py
+++ b/tools/distrib/python/grpcio_tools/grpc_tools/protoc.py
@@ -14,12 +14,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import pkg_resources
+import os
 import sys
 
-import os
-
 from grpc_tools import _protoc_compiler
+import pkg_resources
 
 _PROTO_MODULE_SUFFIX = "_pb2"
 _SERVICE_MODULE_SUFFIX = "_pb2_grpc"

--- a/tools/distrib/python/grpcio_tools/grpc_tools/test/protoc_test.py
+++ b/tools/distrib/python/grpcio_tools/grpc_tools/test/protoc_test.py
@@ -103,7 +103,7 @@ def _test_proto_module_imported_once():
 def _test_static_dynamic_combo():
     with _augmented_syspath(
         ("tools/distrib/python/grpcio_tools/grpc_tools/test/",)):
-        from grpc_tools import protoc
+        from grpc_tools import protoc  # isort:skip
         import complicated_pb2
         protos = protoc._protos("simple.proto")
         static_message = complicated_pb2.ComplicatedMessage()

--- a/tools/distrib/python/grpcio_tools/setup.py
+++ b/tools/distrib/python/grpcio_tools/setup.py
@@ -18,19 +18,18 @@ from distutils import util
 import errno
 import os
 import os.path
-import pkg_resources
 import platform
 import re
 import shlex
 import shutil
+import subprocess
+from subprocess import PIPE
 import sys
 import sysconfig
 
+import pkg_resources
 import setuptools
 from setuptools.command import build_ext
-
-import subprocess
-from subprocess import PIPE
 
 # TODO(atash) add flag to disable Cython use
 
@@ -42,6 +41,7 @@ sys.path.insert(0, os.path.abspath('.'))
 
 import _parallel_compile_patch
 import protoc_lib_deps
+
 import grpc_version
 
 _EXT_INIT_SYMBOL = None

--- a/tools/distrib/python/xds_protos/build.py
+++ b/tools/distrib/python/xds_protos/build.py
@@ -15,8 +15,9 @@
 """Builds the content of xds-protos package"""
 
 import os
-import pkg_resources
+
 from grpc_tools import protoc
+import pkg_resources
 
 # We might not want to compile all the protos
 EXCLUDE_PROTO_PACKAGES_LIST = [

--- a/tools/distrib/python/xds_protos/setup.py
+++ b/tools/distrib/python/xds_protos/setup.py
@@ -15,6 +15,7 @@
 """A PyPI package for xDS protos generated Python code."""
 
 import os
+
 import setuptools
 
 WORK_DIR = os.path.dirname(os.path.abspath(__file__))

--- a/tools/distrib/run_clang_tidy.py
+++ b/tools/distrib/run_clang_tidy.py
@@ -13,11 +13,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import sys
-import os
-import subprocess
 import argparse
 import multiprocessing
+import os
+import subprocess
+import sys
 
 sys.path.append(
     os.path.join(os.path.dirname(sys.argv[0]), '..', 'run_tests',

--- a/tools/gcp/github_stats_tracking/fetch_data.py
+++ b/tools/gcp/github_stats_tracking/fetch_data.py
@@ -12,9 +12,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from github import Github, Label
-from datetime import datetime, timedelta
+from datetime import datetime
+from datetime import timedelta
 from time import time
+
+from github import Github
+from github import Label
 from google.cloud import bigquery
 
 ACCESS_TOKEN = ""

--- a/tools/gcp/github_stats_tracking/main.py
+++ b/tools/gcp/github_stats_tracking/main.py
@@ -12,8 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import webapp2
 from fetch_data import fetch
+import webapp2
 
 
 class DailyCron(webapp2.RequestHandler):

--- a/tools/gcp/utils/big_query_utils.py
+++ b/tools/gcp/utils/big_query_utils.py
@@ -18,10 +18,10 @@ from __future__ import print_function
 import argparse
 import json
 import uuid
-import httplib2
 
 from apiclient import discovery
 from apiclient.errors import HttpError
+import httplib2
 from oauth2client.client import GoogleCredentials
 
 # 30 days in milliseconds

--- a/tools/github/pr_latency.py
+++ b/tools/github/pr_latency.py
@@ -31,12 +31,13 @@ from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
 
+from datetime import datetime
+from datetime import timedelta
 import json
 import logging
 import pprint
-import urllib2
 
-from datetime import datetime, timedelta
+import urllib2
 
 logging.basicConfig(format='%(asctime)s %(message)s')
 

--- a/tools/line_count/collect-history.py
+++ b/tools/line_count/collect-history.py
@@ -13,8 +13,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import subprocess
 import datetime
+import subprocess
 
 # this script is only of historical interest: it's the script that was used to
 # bootstrap the dataset

--- a/tools/line_count/summarize-history.py
+++ b/tools/line_count/summarize-history.py
@@ -13,8 +13,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import subprocess
 import datetime
+import subprocess
 
 # this script is only of historical interest: it's the script that was used to
 # bootstrap the dataset

--- a/tools/line_count/yaml2csv.py
+++ b/tools/line_count/yaml2csv.py
@@ -13,10 +13,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import yaml
 import argparse
-import datetime
 import csv
+import datetime
+
+import yaml
 
 argp = argparse.ArgumentParser(description='Convert cloc yaml to bigquery csv')
 argp.add_argument('-i', '--input', type=str)

--- a/tools/profiling/ios_bin/binary_size.py
+++ b/tools/profiling/ios_bin/binary_size.py
@@ -21,6 +21,7 @@ import os
 import shutil
 import subprocess
 import sys
+
 from parse_link_map import parse_link_map
 
 sys.path.append(

--- a/tools/profiling/ios_bin/parse_link_map.py
+++ b/tools/profiling/ios_bin/parse_link_map.py
@@ -18,8 +18,8 @@
 # symbols.
 # The script takes one parameter, which is the path to the link map file.
 
-import sys
 import re
+import sys
 
 
 def parse_link_map(filename):

--- a/tools/profiling/microbenchmarks/bm2bq.py
+++ b/tools/profiling/microbenchmarks/bm2bq.py
@@ -17,12 +17,12 @@
 # Convert google-benchmark json output to something that can be uploaded to
 # BigQuery
 
-import sys
-import json
 import csv
-import bm_json
 import json
 import subprocess
+import sys
+
+import bm_json
 
 columns = []
 

--- a/tools/profiling/qps/qps_diff.py
+++ b/tools/profiling/qps/qps_diff.py
@@ -19,10 +19,11 @@ import argparse
 import json
 import multiprocessing
 import os
-import qps_scenarios
 import shutil
 import subprocess
 import sys
+
+import qps_scenarios
 import tabulate
 
 sys.path.append(

--- a/tools/release/release_notes.py
+++ b/tools/release/release_notes.py
@@ -26,8 +26,8 @@ X will be v1.17.2. In both cases Y will be origin/v1.17.x.
 
 """
 
-from collections import defaultdict
 import base64
+from collections import defaultdict
 import json
 
 content_header = """Draft Release Notes For {version}
@@ -98,10 +98,14 @@ def get_pr_data(pr_num):
     """Get the PR data from github. Return 'error' on exception"""
 
     try:
-        from urllib2 import Request, urlopen, HTTPError
+        from urllib2 import HTTPError
+        from urllib2 import Request
+        from urllib2 import urlopen
     except ImportError:
         import urllib
-        from urllib.request import Request, urlopen, HTTPError
+        from urllib.request import HTTPError
+        from urllib.request import Request
+        from urllib.request import urlopen
     url = API_URL + pr_num
     req = Request(url)
     req.add_header('Authorization', 'token %s' % TOKEN)

--- a/tools/release/verify_python_release.py
+++ b/tools/release/verify_python_release.py
@@ -30,8 +30,9 @@ import argparse
 import collections
 import hashlib
 import os
-import requests
 import sys
+
+import requests
 
 _DEFAULT_PACKAGES = [
     "grpcio",

--- a/tools/run_tests/lb_interop_tests/gen_build_yaml.py
+++ b/tools/run_tests/lb_interop_tests/gen_build_yaml.py
@@ -16,6 +16,7 @@
 
 import json
 import os
+
 import yaml
 
 all_scenarios = []

--- a/tools/run_tests/performance/bq_upload_result.py
+++ b/tools/run_tests/performance/bq_upload_result.py
@@ -24,6 +24,7 @@ import os
 import sys
 import time
 import uuid
+
 import massage_qps_stats
 
 gcp_utils_dir = os.path.abspath(

--- a/tools/run_tests/performance/loadtest_concat_yaml.py
+++ b/tools/run_tests/performance/loadtest_concat_yaml.py
@@ -22,7 +22,6 @@
 
 import argparse
 import sys
-
 from typing import Iterable
 
 

--- a/tools/run_tests/performance/loadtest_config.py
+++ b/tools/run_tests/performance/loadtest_config.py
@@ -26,18 +26,16 @@ import collections
 import copy
 import datetime
 import itertools
+import json
 import os
 import string
 import sys
-import uuid
-
 from typing import Any, Dict, Iterable, Mapping, Optional, Type
-
-import json
-import yaml
+import uuid
 
 import scenario_config
 import scenario_config_exporter
+import yaml
 
 CONFIGURATION_FILE_HEADER_COMMENT = """
 # Load test configurations generated from a template by loadtest_config.py.

--- a/tools/run_tests/performance/loadtest_template.py
+++ b/tools/run_tests/performance/loadtest_template.py
@@ -27,12 +27,10 @@
 
 import argparse
 import sys
-
 from typing import Any, Dict, Iterable, List, Mapping, Type
 
-import yaml
-
 import loadtest_config
+import yaml
 
 TEMPLATE_FILE_HEADER_COMMENT = """
 # Template generated from load test configurations by loadtest_template.py.

--- a/tools/run_tests/performance/scenario_config_exporter.py
+++ b/tools/run_tests/performance/scenario_config_exporter.py
@@ -42,7 +42,6 @@ import collections
 import json
 import re
 import sys
-
 from typing import Any, Callable, Dict, Iterable, NamedTuple
 
 import scenario_config

--- a/tools/run_tests/python_utils/check_on_pr.py
+++ b/tools/run_tests/python_utils/check_on_pr.py
@@ -13,15 +13,16 @@
 # limitations under the License.
 
 from __future__ import print_function
+
+import datetime
+import json
 import os
 import sys
-import json
 import time
-import datetime
 import traceback
 
-import requests
 import jwt
+import requests
 
 _GITHUB_API_PREFIX = 'https://api.github.com'
 _GITHUB_REPO = 'grpc/grpc'

--- a/tools/run_tests/python_utils/dockerjob.py
+++ b/tools/run_tests/python_utils/dockerjob.py
@@ -15,12 +15,12 @@
 
 from __future__ import print_function
 
+import json
+import os
+import subprocess
 import tempfile
 import time
 import uuid
-import os
-import subprocess
-import json
 
 import jobset
 

--- a/tools/run_tests/python_utils/download_and_unzip.py
+++ b/tools/run_tests/python_utils/download_and_unzip.py
@@ -17,9 +17,10 @@ from __future__ import print_function
 
 import os
 import sys
-import zipfile
-import requests
 import tempfile
+import zipfile
+
+import requests
 
 
 def main():

--- a/tools/run_tests/python_utils/filter_pull_request_tests.py
+++ b/tools/run_tests/python_utils/filter_pull_request_tests.py
@@ -17,8 +17,9 @@
 from __future__ import print_function
 
 import re
-import six
 import subprocess
+
+import six
 
 
 class TestSuite:

--- a/tools/run_tests/python_utils/jobset.py
+++ b/tools/run_tests/python_utils/jobset.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 """Run a group of subprocesses and then finish."""
 
+import errno
 import logging
 import multiprocessing
 import os
@@ -23,7 +24,6 @@ import subprocess
 import sys
 import tempfile
 import time
-import errno
 
 # cpu cost measurement
 measure_cpu_costs = False

--- a/tools/run_tests/python_utils/port_server.py
+++ b/tools/run_tests/python_utils/port_server.py
@@ -17,16 +17,18 @@
 from __future__ import print_function
 
 import argparse
-from six.moves.BaseHTTPServer import HTTPServer, BaseHTTPRequestHandler
-from six.moves.socketserver import ThreadingMixIn
 import hashlib
 import os
+import platform
+import random
 import socket
 import sys
-import time
-import random
 import threading
-import platform
+import time
+
+from six.moves.BaseHTTPServer import BaseHTTPRequestHandler
+from six.moves.BaseHTTPServer import HTTPServer
+from six.moves.socketserver import ThreadingMixIn
 
 # increment this number whenever making a change to ensure that
 # the changes are picked up by running CI servers

--- a/tools/run_tests/python_utils/report_utils.py
+++ b/tools/run_tests/python_utils/report_utils.py
@@ -14,15 +14,16 @@
 """Generate XML and HTML test reports."""
 
 try:
+    from mako import exceptions
     from mako.runtime import Context
     from mako.template import Template
-    from mako import exceptions
 except (ImportError):
     pass  # Mako not installed but it is ok.
 import datetime
 import os
 import string
 import xml.etree.cElementTree as ET
+
 import six
 
 

--- a/tools/run_tests/python_utils/start_port_server.py
+++ b/tools/run_tests/python_utils/start_port_server.py
@@ -15,9 +15,6 @@
 
 from __future__ import print_function
 
-from . import jobset
-
-import six.moves.urllib.request as request
 import logging
 import os
 import socket
@@ -25,6 +22,10 @@ import subprocess
 import sys
 import tempfile
 import time
+
+import six.moves.urllib.request as request
+
+from . import jobset
 
 # must be synchronized with test/core/util/port_server_client.h
 _PORT_SERVER_PORT = 32766

--- a/tools/run_tests/python_utils/upload_rbe_results.py
+++ b/tools/run_tests/python_utils/upload_rbe_results.py
@@ -15,11 +15,12 @@
 """Uploads RBE results to BigQuery"""
 
 import argparse
-import os
 import json
+import os
 import sys
-import urllib2
 import uuid
+
+import urllib2
 
 gcp_utils_dir = os.path.abspath(
     os.path.join(os.path.dirname(__file__), '../../gcp/utils'))

--- a/tools/run_tests/python_utils/upload_test_results.py
+++ b/tools/run_tests/python_utils/upload_test_results.py
@@ -17,10 +17,11 @@
 from __future__ import print_function
 
 import os
-import six
 import sys
 import time
 import uuid
+
+import six
 
 gcp_utils_dir = os.path.abspath(
     os.path.join(os.path.dirname(__file__), '../../gcp/utils'))

--- a/tools/run_tests/python_utils/watch_dirs.py
+++ b/tools/run_tests/python_utils/watch_dirs.py
@@ -15,6 +15,7 @@
 
 import os
 import time
+
 from six import string_types
 
 

--- a/tools/run_tests/run_grpclb_interop_tests.py
+++ b/tools/run_tests/run_grpclb_interop_tests.py
@@ -27,9 +27,10 @@ import subprocess
 import sys
 import tempfile
 import time
-import uuid
-import six
 import traceback
+import uuid
+
+import six
 
 import python_utils.dockerjob as dockerjob
 import python_utils.jobset as jobset

--- a/tools/run_tests/run_interop_tests.py
+++ b/tools/run_tests/run_interop_tests.py
@@ -27,13 +27,15 @@ import subprocess
 import sys
 import tempfile
 import time
-import uuid
-import six
 import traceback
+import uuid
+
+import six
 
 import python_utils.dockerjob as dockerjob
 import python_utils.jobset as jobset
 import python_utils.report_utils as report_utils
+
 # It's ok to not import because this is only necessary to upload results to BQ.
 try:
     from python_utils.upload_test_results import upload_interop_results_to_bq

--- a/tools/run_tests/run_performance_tests.py
+++ b/tools/run_tests/run_performance_tests.py
@@ -30,6 +30,7 @@ import tempfile
 import time
 import traceback
 import uuid
+
 import six
 
 import performance.scenario_config as scenario_config

--- a/tools/run_tests/run_tests.py
+++ b/tools/run_tests/run_tests.py
@@ -34,16 +34,18 @@ import socket
 import subprocess
 import sys
 import tempfile
-import traceback
 import time
-from six.moves import urllib
+import traceback
 import uuid
+
 import six
+from six.moves import urllib
 
 import python_utils.jobset as jobset
 import python_utils.report_utils as report_utils
-import python_utils.watch_dirs as watch_dirs
 import python_utils.start_port_server as start_port_server
+import python_utils.watch_dirs as watch_dirs
+
 try:
     from python_utils.upload_test_results import upload_results_to_bq
 except (ImportError):

--- a/tools/run_tests/run_tests_matrix.py
+++ b/tools/run_tests/run_tests_matrix.py
@@ -21,9 +21,9 @@ import multiprocessing
 import os
 import sys
 
+from python_utils.filter_pull_request_tests import filter_tests
 import python_utils.jobset as jobset
 import python_utils.report_utils as report_utils
-from python_utils.filter_pull_request_tests import filter_tests
 
 _ROOT = os.path.abspath(os.path.join(os.path.dirname(sys.argv[0]), '../..'))
 os.chdir(_ROOT)

--- a/tools/run_tests/run_xds_tests.py
+++ b/tools/run_tests/run_xds_tests.py
@@ -16,8 +16,6 @@
 
 import argparse
 import datetime
-import googleapiclient.discovery
-import grpc
 import json
 import logging
 import os
@@ -30,12 +28,13 @@ import tempfile
 import time
 import uuid
 
-from oauth2client.client import GoogleCredentials
 from google.protobuf import json_format
+import googleapiclient.discovery
+import grpc
+from oauth2client.client import GoogleCredentials
 
 import python_utils.jobset as jobset
 import python_utils.report_utils as report_utils
-
 from src.proto.grpc.health.v1 import health_pb2
 from src.proto.grpc.health.v1 import health_pb2_grpc
 from src.proto.grpc.testing import empty_pb2
@@ -45,12 +44,13 @@ from src.proto.grpc.testing import test_pb2_grpc
 # Envoy protos provided by PyPI package xds-protos
 # Needs to import the generated Python file to load descriptors
 try:
-    from envoy.service.status.v3 import csds_pb2
-    from envoy.service.status.v3 import csds_pb2_grpc
-    from envoy.extensions.filters.network.http_connection_manager.v3 import http_connection_manager_pb2
     from envoy.extensions.filters.common.fault.v3 import fault_pb2
     from envoy.extensions.filters.http.fault.v3 import fault_pb2
     from envoy.extensions.filters.http.router.v3 import router_pb2
+    from envoy.extensions.filters.network.http_connection_manager.v3 import \
+        http_connection_manager_pb2
+    from envoy.service.status.v3 import csds_pb2
+    from envoy.service.status.v3 import csds_pb2_grpc
 except ImportError:
     # These protos are required by CSDS test. We should not fail the entire
     # script for one test case.

--- a/tools/run_tests/sanity/check_qps_scenario_changes.py
+++ b/tools/run_tests/sanity/check_qps_scenario_changes.py
@@ -15,8 +15,8 @@
 # limitations under the License.
 
 import os
-import sys
 import subprocess
+import sys
 
 os.chdir(os.path.join(os.path.dirname(sys.argv[0]), '../../../test/cpp/qps'))
 subprocess.call(['./json_run_localhost_scenario_gen.py'])

--- a/tools/run_tests/sanity/check_test_filtering.py
+++ b/tools/run_tests/sanity/check_test_filtering.py
@@ -15,14 +15,15 @@
 # limitations under the License.
 
 import os
+import re
 import sys
 import unittest
-import re
 
 # hack import paths to pick up extra code
 sys.path.insert(0, os.path.abspath('tools/run_tests/'))
-from run_tests_matrix import _create_test_jobs, _create_portability_test_jobs
 import python_utils.filter_pull_request_tests as filter_pull_request_tests
+from run_tests_matrix import _create_portability_test_jobs
+from run_tests_matrix import _create_test_jobs
 
 _LIST_OF_LANGUAGE_LABELS = [
     'c', 'c++', 'csharp', 'grpc-node', 'objc', 'php', 'php7', 'python', 'ruby'

--- a/tools/run_tests/sanity/check_tracer_sanity.py
+++ b/tools/run_tests/sanity/check_tracer_sanity.py
@@ -15,8 +15,8 @@
 # limitations under the License.
 
 import os
-import sys
 import re
+import sys
 
 os.chdir(os.path.join(os.path.dirname(sys.argv[0]), '../../..'))
 

--- a/tools/run_tests/sanity/check_version.py
+++ b/tools/run_tests/sanity/check_version.py
@@ -14,11 +14,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import sys
-import yaml
 import os
 import re
 import subprocess
+import sys
+
+import yaml
 
 errors = 0
 

--- a/tools/run_tests/sanity/sanity_tests.yaml
+++ b/tools/run_tests/sanity/sanity_tests.yaml
@@ -32,5 +32,7 @@
 - script: tools/distrib/python/check_grpcio_tools.py
 - script: tools/distrib/yapf_code.sh --diff
   cpu_cost: 1000
+- script: tools/distrib/isort_code.sh --diff
+  cpu_cost: 1000
 - script: tools/distrib/check_protobuf_pod_version.sh
 - script: tools/distrib/check_boringssl_prefix_symbol.sh

--- a/tools/run_tests/xds_k8s_test_driver/framework/test_app/client_app.py
+++ b/tools/run_tests/xds_k8s_test_driver/framework/test_app/client_app.py
@@ -20,7 +20,7 @@ modules.
 import datetime
 import functools
 import logging
-from typing import Iterable, Optional, Tuple, List
+from typing import Iterable, List, Optional, Tuple
 
 from framework.helpers import retryers
 from framework.infrastructure import gcp

--- a/tools/run_tests/xds_k8s_test_driver/tests/url_map/affinity_test.py
+++ b/tools/run_tests/xds_k8s_test_driver/tests/url_map/affinity_test.py
@@ -20,9 +20,9 @@ from absl.testing import absltest
 
 from framework import xds_k8s_flags
 from framework import xds_url_map_testcase
+from framework.infrastructure import traffic_director
 from framework.rpc import grpc_channelz
 from framework.test_app import client_app
-from framework.infrastructure import traffic_director
 
 # Type aliases
 HostRule = xds_url_map_testcase.HostRule


### PR DESCRIPTION
* Add isort_code.sh to sanity tests

* Run tools/distrib/isort_code.sh

* Fine tune the import order for relative imports

* Make pylint and project generation happy

* Fix a few corner cases

* Use --check instead of --diff

* The import order impacts test result somehow

* Make isort print diff and check output at the same time

* Let tools/run_tests/python_utils be firstparty library

* Run isort against latest HEAD




<!--

Your pull request will be routed to the following person by default for triaging.
If you know who should review your pull request, please remove the mentioning below.

-->

@nicolasnoble
